### PR TITLE
feat: use less progmem(flash) and ram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # OBDisplay-Uno
 
 [![CI/CD](https://github.com/RXTX4816/OBDisplay-Uno/actions/workflows/ci.yml/badge.svg)](https://github.com/RXTX4816/OBDisplay-Uno/actions)
-[![Flash: 96.2%](https://img.shields.io/badge/flash-96.2%25_of_32256B-red)](https://github.com/RXTX4816/OBDisplay-Uno)
-[![RAM: 56.5%](https://img.shields.io/badge/RAM-56.5%25_of_2048B-green)](https://github.com/RXTX4816/OBDisplay-Uno)
-[![Flash (debug): 100%](https://img.shields.io/badge/flash_(debug)-100%25_of_32256B-red)](https://github.com/RXTX4816/OBDisplay-Uno)
-[![RAM (debug): 65.0%](https://img.shields.io/badge/RAM_(debug)-65.0%25_of_2048B-yellow)](https://github.com/RXTX4816/OBDisplay-Uno)
+[![Flash: 71.4%](https://img.shields.io/badge/flash-71.4%25_of_32256B-red)](https://github.com/RXTX4816/OBDisplay-Uno)
+[![RAM: 36.0%](https://img.shields.io/badge/RAM-36.0%25_of_2048B-green)](https://github.com/RXTX4816/OBDisplay-Uno)
+[![Flash (debug): 75.5%](https://img.shields.io/badge/flash_(debug)-75.5%25_of_32256B-red)](https://github.com/RXTX4816/OBDisplay-Uno)
+[![RAM (debug): 44.5%](https://img.shields.io/badge/RAM_(debug)-44.5%25_of_2048B-yellow)](https://github.com/RXTX4816/OBDisplay-Uno)
 [![MCU: ATmega328P](https://img.shields.io/badge/MCU-ATmega328P-blue)](https://www.microchip.com/en-us/product/atmega328p)
 
 KWP-1281 K-Line trip computer for Arduino Uno with SH1107 OLED display (64×128, landscape mode work in progress).

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,8 +20,6 @@ build_flags =
   -fdata-sections
   -Wl,--gc-sections
   -D OBD_EXPERIMENTAL_SCREENS
-lib_deps =
-  arkhipenko/TaskScheduler @ ^3.7.0
 
 [env:uno_debug]
 platform = atmelavr
@@ -32,8 +30,6 @@ build_flags =
   ${env:uno.build_flags}
   -D OBD_DEBUG
   -D OBD_EXPERIMENTAL_SCREENS
-lib_deps =
-  arkhipenko/TaskScheduler @ ^3.7.0
 
 [env:native]
 platform = native

--- a/src/display/Display.cpp
+++ b/src/display/Display.cpp
@@ -1,11 +1,49 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "Display.h"
 #include "../debug.h"
-#include <Wire.h>
+#include <avr/io.h>
 
 namespace
 {
 constexpr uint8_t OLED_I2C_ADDR = 0x3C;
+
+// Minimal blocking TWI driver — master TX only, single fixed address.
+// Replaces Arduino Wire (~1.3 KB) for write-only OLED communication.
+static void twiInit()
+{
+    PORTC |= (1 << PC4) | (1 << PC5); // pull-ups on SDA/SCL
+    TWSR = 0;                         // prescaler = 1
+    TWBR = 72;                        // 100 kHz @ 16 MHz: (16e6/100e3 - 16) / 2
+}
+
+static void twiWait()
+{
+    while (!(TWCR & (1 << TWINT)))
+        ;
+}
+
+static void twiStart(uint8_t addr)
+{
+    TWCR = (1 << TWINT) | (1 << TWSTA) | (1 << TWEN);
+    twiWait();
+    TWDR = (uint8_t)(addr << 1); // write direction
+    TWCR = (1 << TWINT) | (1 << TWEN);
+    twiWait();
+}
+
+static void twiWrite(uint8_t b)
+{
+    TWDR = b;
+    TWCR = (1 << TWINT) | (1 << TWEN);
+    twiWait();
+}
+
+static void twiStop()
+{
+    TWCR = (1 << TWINT) | (1 << TWEN) | (1 << TWSTO);
+    while (TWCR & (1 << TWSTO))
+        ;
+}
 
 // SH1107 initialization sequence (from U8g2 driver, proven working).
 // Each command is sent individually with delays for stability.
@@ -130,10 +168,10 @@ const uint8_t PROGMEM kFont[] = {
 
 void writeCmd(uint8_t c)
 {
-    Wire.beginTransmission(OLED_I2C_ADDR);
-    Wire.write(0x00); // control byte: command
-    Wire.write(c);
-    Wire.endTransmission();
+    twiStart(OLED_I2C_ADDR);
+    twiWrite(0x00); // control byte: command
+    twiWrite(c);
+    twiStop();
 }
 
 void sendInit()
@@ -152,8 +190,7 @@ void sendInit()
 void Display::begin()
 {
     DBG(DBG_DISP_INIT);
-    Wire.begin();
-    Wire.setClock(100000);
+    twiInit();
     DBG(DBG_DISP_WIRE_OK);
 
     DBG(DBG_DISP_OFF);
@@ -173,11 +210,11 @@ void Display::begin()
         writeCmd(0x00);
         writeCmd(0x12); // CRITICAL: column high nibble = 0x12
 
-        Wire.beginTransmission(OLED_I2C_ADDR);
-        Wire.write(0x40); // control byte: data stream
+        twiStart(OLED_I2C_ADDR);
+        twiWrite(0x40); // control byte: data stream
         for (uint8_t col = 0; col < 64; ++col)
-            Wire.write(0x00);
-        Wire.endTransmission();
+            twiWrite(0x00);
+        twiStop();
     }
     DBG(DBG_DISP_READY);
 }
@@ -334,16 +371,16 @@ void Display::flush()
         uint8_t col = 0;
         while (col < 64)
         {
-            Wire.beginTransmission(OLED_I2C_ADDR);
-            Wire.write(0x40); // data stream control byte
+            twiStart(OLED_I2C_ADDR);
+            twiWrite(0x40); // data stream control byte
             uint8_t n = 0;
             while (col < 64 && n < 16)
             {
-                Wire.write(pageBuf[col]);
+                twiWrite(pageBuf[col]);
                 ++col;
                 ++n;
             }
-            Wire.endTransmission();
+            twiStop();
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,12 +6,19 @@
 
 static Controller controller;
 
-static Task tKwp(INTERVAL_KWP_MS, TASK_FOREVER, &Controller::taskKwp);
-static Task tInput(INTERVAL_INPUT_MS, TASK_FOREVER, &Controller::taskInput);
-static Task tCompute(INTERVAL_COMPUTE_MS, TASK_FOREVER, &Controller::taskCompute);
-static Task tDisplay(INTERVAL_DISPLAY_MS, TASK_FOREVER, &Controller::taskDisplay);
+struct SimpleTask
+{
+    uint16_t interval; // ms; 0 = run every iteration
+    uint32_t next;
+    void (*fn)();
+};
 
-static Scheduler runner;
+static SimpleTask tasks[] = {
+    {INTERVAL_KWP_MS, 0, Controller::taskKwp},
+    {INTERVAL_INPUT_MS, 0, Controller::taskInput},
+    {INTERVAL_COMPUTE_MS, 0, Controller::taskCompute},
+    {INTERVAL_DISPLAY_MS, 0, Controller::taskDisplay},
+};
 
 void setup()
 {
@@ -23,7 +30,7 @@ void setup()
 #ifdef OBD_DEBUG
     Serial.begin(115200);
     delay(500);
-    DBG(DBG_CTRL_STEP); // step 0: serial ready
+    DBG(DBG_CTRL_STEP);
 #endif
 
     digitalWrite(13, HIGH);
@@ -31,29 +38,19 @@ void setup()
     digitalWrite(13, LOW);
 
     controller.setup();
-    DBG(DBG_CTRL_STEP); // step 0 repeated here is fine; Controller.cpp sends step 1/2/3
-
-    runner.init();
-    runner.addTask(tKwp);
-    runner.addTask(tInput);
-    runner.addTask(tCompute);
-    runner.addTask(tDisplay);
-
-    tKwp.enable();
-    tInput.enable();
-    tCompute.enable();
-    tDisplay.enable();
+    DBG(DBG_CTRL_STEP);
 }
 
 void loop()
 {
-    // The scheduler calls enabled task callbacks at their configured intervals.
-    // KWP (tKwp interval = 0) runs on every execute() call, ensuring the
-    // timing-critical ECU serial work is never starved by display or compute tasks.
-    runner.execute();
-
-    // OBDDisplay::update() contains the cooperative state machine.
-    // Until the task callbacks are fully wired to individual sub-systems,
-    // the full update still runs here so nothing is broken.
+    uint32_t now = millis();
+    for (auto& t : tasks)
+    {
+        if (now >= t.next)
+        {
+            t.fn();
+            t.next = (t.interval == 0) ? 0 : now + t.interval;
+        }
+    }
     controller.loop();
 }

--- a/src/obd/Display/DisplayManager.cpp
+++ b/src/obd/Display/DisplayManager.cpp
@@ -123,7 +123,7 @@ void DisplayManager::initMenu(const Input::MenuState& menuState, uint8_t addrSel
     switch (menuState.currentMenu())
     {
         case MenuId::Cockpit:
-            initMenuCockpit(menuState.cockpitScreen(), addrSelected);
+            initMenuCockpit(menuState.screen(MenuId::Cockpit), addrSelected);
             break;
         case MenuId::Experimental:
             initMenuExperimental();
@@ -132,10 +132,10 @@ void DisplayManager::initMenu(const Input::MenuState& menuState, uint8_t addrSel
             initMenuDebug();
             break;
         case MenuId::Dtc:
-            initMenuDtc(menuState.dtcScreen());
+            initMenuDtc(menuState.screen(MenuId::Dtc));
             break;
         case MenuId::Settings:
-            initMenuSettings(menuState.settingsScreen());
+            initMenuSettings(menuState.screen(MenuId::Settings));
             break;
     }
 }
@@ -147,19 +147,20 @@ void DisplayManager::render(const Input::MenuState& menuState, const Model::OBDS
     switch (menuState.currentMenu())
     {
         case MenuId::Cockpit:
-            displayMenuCockpit(menuState.cockpitScreen(), addrSelected, signals, forceUpdate);
+            displayMenuCockpit(menuState.screen(MenuId::Cockpit), addrSelected, signals,
+                               forceUpdate);
             break;
         case MenuId::Experimental:
-            displayMenuExperimental(menuState.experimentalScreen(), signals, forceUpdate);
+            displayMenuExperimental(menuState.screen(MenuId::Experimental), signals, forceUpdate);
             break;
         case MenuId::Debug:
-            displayMenuDebug(menuState.debugScreen(), signals, kwpModeInt, forceUpdate);
+            displayMenuDebug(menuState.screen(MenuId::Debug), signals, kwpModeInt, forceUpdate);
             break;
         case MenuId::Dtc:
-            displayMenuDtc(menuState.dtcScreen(), dtcStore, forceUpdate);
+            displayMenuDtc(menuState.screen(MenuId::Dtc), dtcStore, forceUpdate);
             break;
         case MenuId::Settings:
-            displayMenuSettings(menuState.settingsScreen(), kwpModeInt, forceUpdate);
+            displayMenuSettings(menuState.screen(MenuId::Settings), kwpModeInt, forceUpdate);
             break;
     }
 }

--- a/src/obd/Display/DisplayManager.cpp
+++ b/src/obd/Display/DisplayManager.cpp
@@ -74,29 +74,30 @@ void DisplayManager::print(uint8_t x, uint8_t y, const char* s, uint8_t width) c
     display_.print(buf);
 }
 
-// Format a float to one decimal place without pulling in dtostrf/dtoa
-// (saves ~1KB flash). Values here are small (temps, voltages, fuel).
-static void fmtFixed1(float value, char* out)
+// Format a ×10 fixed-point integer with one decimal place (e.g. 123 → "12.3").
+// No float arithmetic — avoids the entire soft-float library on AVR.
+static void fmtScaled(int32_t value, char* out)
 {
-    bool neg = value < 0.0f;
-    if (neg)
-        value = -value;
-    uint32_t scaled = (uint32_t)(value * 10.0f + 0.5f);
     char* p = out;
-    if (neg)
+    if (value < 0)
+    {
         *p++ = '-';
-    utoa((uint16_t)(scaled / 10), p, 10);
+        value = -value;
+    }
+    uint32_t u = (uint32_t)value;
+    utoa((uint16_t)(u / 10), p, 10);
     while (*p != '\0')
         ++p;
     *p++ = '.';
-    *p++ = (char)('0' + (scaled % 10));
+    *p++ = (char)('0' + (u % 10));
     *p = '\0';
 }
 
-void DisplayManager::print(uint8_t x, uint8_t y, float value, uint8_t width) const
+void DisplayManager::print(uint8_t x, uint8_t y, int32_t value, uint8_t /*decimals*/,
+                           uint8_t width) const
 {
     char tmp[12];
-    fmtFixed1(value, tmp);
+    fmtScaled(value, tmp);
     if (width == 0)
     {
         display_.setCursor(x, y);

--- a/src/obd/Display/DisplayManager.h
+++ b/src/obd/Display/DisplayManager.h
@@ -56,7 +56,8 @@ class DisplayManager
     void print(uint8_t x, uint8_t y, const char* s) const;
     void print(uint8_t x, uint8_t y, const char* s, uint8_t width) const;
     void print(uint8_t x, uint8_t y, int32_t value) const;
-    void print(uint8_t x, uint8_t y, float value, uint8_t width = 0) const;
+    // Print a ×10 fixed-point value with one decimal place (e.g. 123 → "12.3").
+    void print(uint8_t x, uint8_t y, int32_t value, uint8_t decimals, uint8_t width = 0) const;
     void clearRegion(uint8_t x, uint8_t y, uint8_t width);
 
   private:

--- a/src/obd/Display/ScreenVM.cpp
+++ b/src/obd/Display/ScreenVM.cpp
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "ScreenVM.h"
+#include "DisplayManager.h"
+
+namespace obd
+{
+namespace Display
+{
+
+static int32_t getFieldInt(FieldId fid, const ScreenCtx& ctx)
+{
+    const Model::OBDSignals* s = ctx.signals;
+    const DebugInfo* d = ctx.debug;
+    switch (fid)
+    {
+        // InstrumentSignals
+        case FLD_VEH_SPEED:
+            return s ? (int32_t)s->instruments.vehicleSpeed : 0;
+        case FLD_ENG_RPM:
+            return s ? (int32_t)s->instruments.engineRpm : 0;
+        case FLD_COOLANT_T:
+            return s ? (int32_t)s->instruments.coolantTemp : 0;
+        case FLD_OIL_T:
+            return s ? (int32_t)s->instruments.oilTemp : 0;
+        case FLD_AMB_T:
+            return s ? (int32_t)s->instruments.ambientTemp : 0;
+        case FLD_OIL_LVL:
+            return s ? (int32_t)s->instruments.oilLevelOk : 0;
+        case FLD_OIL_PRES:
+            return s ? (int32_t)s->instruments.oilPressureMin : 0;
+        case FLD_ODOMETER:
+            return s ? (int32_t)s->instruments.odometer : 0;
+        case FLD_FUEL_LVL:
+            return s ? (int32_t)s->instruments.fuelLevel : 0;
+        case FLD_FUEL_RES:
+            return s ? (int32_t)s->instruments.fuelSensorResistance : 0;
+        case FLD_TIME_ECU:
+            return s ? (int32_t)s->instruments.timeEcu : 0;
+        // ComputedStats
+        case FLD_FUEL_100:
+            return s ? (int32_t)s->computed.fuelPer100km : 0;
+        case FLD_FUEL_H:
+            return s ? (int32_t)s->computed.fuelPerHour : 0;
+        case FLD_ELAPSED_KM:
+            return s ? (int32_t)s->computed.elapsedKmSinceStart : 0;
+        case FLD_FUEL_BURNED:
+            return s ? (int32_t)s->computed.fuelBurnedSinceStart : 0;
+        // EngineSignals
+        case FLD_VOLTAGE:
+            return s ? (int32_t)s->engine.voltage : 0;
+        case FLD_TEMP1:
+            return s ? (int32_t)s->engine.tempUnknown1 : 0;
+        case FLD_TEMP2:
+            return s ? (int32_t)s->engine.tempUnknown2 : 0;
+        case FLD_TEMP3:
+            return s ? (int32_t)s->engine.tempUnknown3 : 0;
+        case FLD_LAMBDA:
+            return s ? (int32_t)s->engine.lambda : 0;
+        case FLD_LAMBDA2:
+            return s ? (int32_t)s->engine.lambda2 : 0;
+        case FLD_ENG_LOAD:
+            return s ? (int32_t)s->engine.engineLoad : 0;
+        case FLD_TB_ANGLE:
+            return s ? (int32_t)s->engine.tbAngle : 0;
+        case FLD_STEER_ANGLE:
+            return s ? (int32_t)s->engine.steeringAngle : 0;
+        case FLD_PRESSURE:
+            return s ? (int32_t)s->engine.pressure : 0;
+        // ExperimentalGroup
+        case FLD_EXP_GRP:
+            return s ? (int32_t)s->experimental.groupCurrent : 0;
+        case FLD_EXP_V0:
+            return s ? s->experimental.v[0] : 0;
+        case FLD_EXP_V1:
+            return s ? s->experimental.v[1] : 0;
+        case FLD_EXP_V2:
+            return s ? s->experimental.v[2] : 0;
+        case FLD_EXP_V3:
+            return s ? s->experimental.v[3] : 0;
+        // DebugInfo
+        case FLD_DBG_CON:
+            return d ? (int32_t)d->serialCon : 0;
+        case FLD_DBG_AVA:
+            return d ? (int32_t)d->serialAva : 0;
+        case FLD_DBG_BC:
+            return d ? (int32_t)d->blockCtr : 0;
+        case FLD_DBG_GRP:
+            return d ? (int32_t)d->group : 0;
+        case FLD_DBG_ADDR:
+            return d ? (int32_t)d->addr : 0;
+        case FLD_DBG_BAUD:
+            return d ? (int32_t)d->baud : 0;
+        case FLD_DBG_ATT:
+            return d ? (int32_t)d->attempts : 0;
+        case FLD_DBG_SIM:
+            return d ? (int32_t)d->sim : 0;
+        case FLD_DBG_RAM:
+            return d ? (int32_t)d->freeRam : 0;
+        // Context
+        case FLD_KWP_MODE:
+            return (int32_t)ctx.kwpMode;
+        default:
+            return 0;
+    }
+}
+
+static const char* getFieldStr(FieldId fid, const ScreenCtx& ctx)
+{
+    const Model::OBDSignals* s = ctx.signals;
+    switch (fid)
+    {
+        case FLD_ERR_BITS_STR:
+            return s ? s->engine.bitsAsString : "";
+        case FLD_EXP_U0:
+            return s ? s->experimental.unit[0] : "";
+        case FLD_EXP_U1:
+            return s ? s->experimental.unit[1] : "";
+        case FLD_EXP_U2:
+            return s ? s->experimental.unit[2] : "";
+        case FLD_EXP_U3:
+            return s ? s->experimental.unit[3] : "";
+        default:
+            return "";
+    }
+}
+
+void runScript(const uint8_t* p, const ScreenCtx& ctx, const DisplayManager& dm)
+{
+    uint8_t op;
+    while ((op = pgm_read_byte(p++)) != SO_END)
+    {
+        uint8_t x = pgm_read_byte(p++);
+        uint8_t y = pgm_read_byte(p++);
+        uint8_t fid = 0;
+        switch (op)
+        {
+            case SO_LABEL:
+            {
+                uint8_t len = pgm_read_byte(p++);
+                char buf[15];
+                for (uint8_t i = 0; i < len; ++i)
+                    buf[i] = (char)pgm_read_byte(p++);
+                buf[len] = '\0';
+                dm.print(x, y, buf);
+                break;
+            }
+            case SO_U8:
+            case SO_U16:
+            case SO_U32:
+            case SO_I8:
+            case SO_I16:
+                fid = pgm_read_byte(p++);
+                dm.print(x, y, getFieldInt((FieldId)fid, ctx));
+                break;
+
+            case SO_SCALED:
+            {
+                fid = pgm_read_byte(p++);
+                uint8_t w = pgm_read_byte(p++);
+                dm.print(x, y, getFieldInt((FieldId)fid, ctx), 1, w);
+                break;
+            }
+            case SO_STR:
+                fid = pgm_read_byte(p++);
+                dm.print(x, y, getFieldStr((FieldId)fid, ctx));
+                break;
+
+            case SO_BOOL_YN:
+                fid = pgm_read_byte(p++);
+                dm.print(x, y, getFieldInt((FieldId)fid, ctx) ? F("Y") : F("N"));
+                break;
+
+            case SO_HEX_U8:
+            {
+                fid = pgm_read_byte(p++);
+                char buf[5];
+                buf[0] = '0';
+                buf[1] = 'x';
+                ltoa(getFieldInt((FieldId)fid, ctx), buf + 2, 16);
+                dm.print(x, y, buf);
+                break;
+            }
+            case SO_CURSOR:
+            {
+                uint8_t target = pgm_read_byte(p++);
+                uint8_t len = pgm_read_byte(p++);
+                char buf[15];
+                buf[0] = (ctx.cursor == target) ? '>' : ' ';
+                for (uint8_t i = 0; i < len; ++i)
+                    buf[i + 1] = (char)pgm_read_byte(p++);
+                buf[len + 1] = '\0';
+                dm.print(x, y, buf);
+                break;
+            }
+            case SO_MODE_STR:
+                p++; // consume fid (always kwpMode, already in ctx)
+                switch (ctx.kwpMode)
+                {
+                    case 0:
+                        dm.print(x, y, F("ACK"));
+                        break;
+                    case 2:
+                        dm.print(x, y, F("Grp"));
+                        break;
+                    default:
+                        dm.print(x, y, F("Sensor"));
+                        break;
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+}
+
+} // namespace Display
+} // namespace obd

--- a/src/obd/Display/ScreenVM.h
+++ b/src/obd/Display/ScreenVM.h
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Minimal PROGMEM byte-stream screen VM.
+// Each screen is a static const uint8_t[] script interpreted by runScript().
+// Adding a new screen requires only a new PROGMEM script array — no new code.
+#pragma once
+
+#include <avr/pgmspace.h>
+#include <stdint.h>
+#include "../Model/OBDSignals.h"
+
+namespace obd
+{
+namespace Display
+{
+
+struct DebugInfo; // forward — defined in DisplayManager.h
+class DisplayManager;
+
+enum ScreenOp : uint8_t
+{
+    SO_END = 0x00,      // end of script
+    SO_LABEL = 0x01,    // [x, y, len, chars...]
+    SO_U8 = 0x02,       // [x, y, fid]
+    SO_U16 = 0x03,      // [x, y, fid]
+    SO_U32 = 0x04,      // [x, y, fid]
+    SO_I8 = 0x05,       // [x, y, fid]
+    SO_I16 = 0x06,      // [x, y, fid]
+    SO_SCALED = 0x07,   // [x, y, fid, width] — ×10 fixed-point, 1 decimal place
+    SO_STR = 0x08,      // [x, y, fid]         — null-terminated char*
+    SO_BOOL_YN = 0x09,  // [x, y, fid]         — prints "Y" or "N"
+    SO_HEX_U8 = 0x0A,   // [x, y, fid]         — prints "0xNN"
+    SO_CURSOR = 0x0B,   // [x, y, target, len, chars...] — ">label" or " label"
+    SO_MODE_STR = 0x0C, // [x, y, fid]         — ACK/Grp/Sensor from uint8_t kwpMode
+};
+
+enum FieldId : uint8_t
+{
+    // InstrumentSignals
+    FLD_VEH_SPEED,
+    FLD_ENG_RPM,
+    FLD_COOLANT_T,
+    FLD_OIL_T,
+    FLD_AMB_T,
+    FLD_OIL_LVL,
+    FLD_OIL_PRES,
+    FLD_ODOMETER,
+    FLD_FUEL_LVL,
+    FLD_FUEL_RES,
+    FLD_TIME_ECU,
+    // ComputedStats
+    FLD_FUEL_100,
+    FLD_FUEL_H,
+    FLD_ELAPSED_KM,
+    FLD_FUEL_BURNED,
+    // EngineSignals
+    FLD_VOLTAGE,
+    FLD_TEMP1,
+    FLD_TEMP2,
+    FLD_TEMP3,
+    FLD_LAMBDA,
+    FLD_LAMBDA2,
+    FLD_ENG_LOAD,
+    FLD_TB_ANGLE,
+    FLD_STEER_ANGLE,
+    FLD_PRESSURE,
+    FLD_ERR_BITS_STR, // char* — bitsAsString, assembled by caller before runScript()
+                      // ExperimentalGroup
+    FLD_EXP_GRP,
+    FLD_EXP_V0,
+    FLD_EXP_V1,
+    FLD_EXP_V2,
+    FLD_EXP_V3,
+    FLD_EXP_U0, // char*
+    FLD_EXP_U1, // char*
+    FLD_EXP_U2, // char*
+    FLD_EXP_U3, // char*
+                // DebugInfo
+    FLD_DBG_CON,
+    FLD_DBG_AVA,
+    FLD_DBG_BC,
+    FLD_DBG_GRP,
+    FLD_DBG_ADDR,
+    FLD_DBG_BAUD,
+    FLD_DBG_ATT,
+    FLD_DBG_SIM,
+    FLD_DBG_RAM,
+    // Context
+    FLD_KWP_MODE,
+};
+
+struct ScreenCtx
+{
+    const Model::OBDSignals* signals; // nullptr for debug-only screens
+    const DebugInfo* debug;           // nullptr for signal-only screens
+    uint8_t cursor;
+    uint8_t kwpMode;
+};
+
+void runScript(const uint8_t* pgm_script, const ScreenCtx& ctx, const DisplayManager& dm);
+
+} // namespace Display
+} // namespace obd

--- a/src/obd/Display/screens/CockpitScreen.cpp
+++ b/src/obd/Display/screens/CockpitScreen.cpp
@@ -127,13 +127,13 @@ void renderCockpitScreen(DisplayManager& dm, uint8_t screen, uint8_t addrSelecte
             ltoa(ins.timeEcu, buf + 3, 10);
             dm.print(0, 9, buf);
 
-            // Row 10: L100:X.X (fuel consumption per 100km)
+            // Row 10: L100:X.X (fuel consumption per 100km, ×10 fixed-point)
             dm.print(0, 10, F("L100:"));
-            dm.print(5, 10, c.fuelPer100km, 5);
+            dm.print(5, 10, (int32_t)c.fuelPer100km, 1, 5);
 
-            // Row 11: L/h:X.X (fuel consumption per hour)
+            // Row 11: L/h:X.X (fuel consumption per hour, ×10 fixed-point)
             dm.print(0, 11, F("L/h:"));
-            dm.print(4, 11, c.fuelPerHour, 4);
+            dm.print(4, 11, (int32_t)c.fuelPerHour, 1, 4);
 
             // Row 12: km:XXXXX (distance since start)
             buf[0] = 'k';
@@ -142,9 +142,9 @@ void renderCockpitScreen(DisplayManager& dm, uint8_t screen, uint8_t addrSelecte
             ltoa(c.elapsedKmSinceStart, buf + 3, 10);
             dm.print(0, 12, buf);
 
-            // Row 13: L:X.X (fuel burned since start)
+            // Row 13: L:XX (fuel burned since start, integer litres)
             dm.print(0, 13, F("L:"));
-            dm.print(2, 13, c.fuelBurnedSinceStart, 5);
+            dm.print(2, 13, (int32_t)c.fuelBurnedSinceStart);
 
             break;
         }
@@ -167,9 +167,9 @@ void renderCockpitScreen(DisplayManager& dm, uint8_t screen, uint8_t addrSelecte
                     ltoa(ins.engineRpm, buf + 4, 10);
                     dm.print(0, 0, buf);
 
-                    // Row 1: V:X.XXX
+                    // Row 1: V:X.X (voltage ×10 fixed-point)
                     dm.print(0, 1, F("V:"));
-                    dm.print(2, 1, e.voltage, 5);
+                    dm.print(2, 1, (int32_t)e.voltage, 1, 5);
 
                     // Row 2: T1:XXX
                     buf[0] = 'T';
@@ -221,13 +221,13 @@ void renderCockpitScreen(DisplayManager& dm, uint8_t screen, uint8_t addrSelecte
 
                 case 1:
                 {
-                    // Row 0: TBa:X.X
+                    // Row 0: TBa:X.X (×10 fixed-point)
                     dm.print(0, 0, F("TBa:"));
-                    dm.print(4, 0, e.tbAngle, 5);
+                    dm.print(4, 0, (int32_t)e.tbAngle, 1, 5);
 
-                    // Row 1: STa:X.X
+                    // Row 1: STa:X.X (×10 fixed-point)
                     dm.print(0, 1, F("STa:"));
-                    dm.print(4, 1, e.steeringAngle, 5);
+                    dm.print(4, 1, (int32_t)e.steeringAngle, 1, 5);
 
                     // Row 2: mb:XXXX
                     buf[0] = 'm';

--- a/src/obd/Display/screens/CockpitScreen.cpp
+++ b/src/obd/Display/screens/CockpitScreen.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "CockpitScreen.h"
-#include "ScreenHelpers.h"
+#include "../ScreenVM.h"
 
 // Portrait layout (10 cols x 16 rows):
 //
@@ -11,7 +11,7 @@
 //   Row 3:  OIL:XXX     Row 10: L100:X.X
 //   Row 4:  AMB:XXX     Row 11: L/h:X.X
 //   Row 5:  OL:X OP:X   Row 12: km:XXXXX
-//   Row 6:  ODO:XXXXXX  Row 13: L:X.X
+//   Row 6:  ODO:XXXXXX  Row 13: L:XX
 //
 // ADDR_ENGINE (0x01):
 //   Screen 0: 8 signals stacked vertically
@@ -22,265 +22,101 @@ namespace obd
 namespace Display
 {
 
-void initCockpitScreen(DisplayManager& /*dm*/, uint8_t /*screen*/, uint8_t /*addrSelected*/)
-{
-    // No-op: all rendering (labels + values) is done in renderCockpitScreen.
-}
+// clang-format off
+static const uint8_t PROGMEM kCockpit17Script[] = {
+    SO_LABEL,  0,  0, 4, 'S','P','D',':',   SO_U16,    4,  0, FLD_VEH_SPEED,
+    SO_LABEL,  0,  1, 4, 'R','P','M',':',   SO_U16,    4,  1, FLD_ENG_RPM,
+    SO_LABEL,  0,  2, 4, 'C','L','T',':',   SO_U8,     4,  2, FLD_COOLANT_T,
+    SO_LABEL,  0,  3, 4, 'O','I','L',':',   SO_U8,     4,  3, FLD_OIL_T,
+    SO_LABEL,  0,  4, 4, 'A','M','B',':',   SO_U8,     4,  4, FLD_AMB_T,
+    // Row 5: OL:X OP:X — two bool fields on one row
+    SO_LABEL,  0,  5, 3, 'O','L',':',       SO_U8,     3,  5, FLD_OIL_LVL,
+    SO_LABEL,  5,  5, 3, 'O','P',':',       SO_U8,     8,  5, FLD_OIL_PRES,
+    SO_LABEL,  0,  6, 4, 'O','D','O',':',   SO_U32,    4,  6, FLD_ODOMETER,
+    SO_LABEL,  0,  7, 4, 'F','U','L',':',   SO_U8,     4,  7, FLD_FUEL_LVL,
+    SO_LABEL,  0,  8, 4, 'F','S','R',':',   SO_U16,    4,  8, FLD_FUEL_RES,
+    SO_LABEL,  0,  9, 3, 'T','M', ':',      SO_U32,    3,  9, FLD_TIME_ECU,
+    SO_LABEL,  0, 10, 5, 'L','1','0','0',':', SO_SCALED, 5, 10, FLD_FUEL_100, 5,
+    SO_LABEL,  0, 11, 4, 'L','/','h',':',   SO_SCALED, 4, 11, FLD_FUEL_H,   4,
+    SO_LABEL,  0, 12, 3, 'k','m', ':',      SO_U16,    3, 12, FLD_ELAPSED_KM,
+    SO_LABEL,  0, 13, 2, 'L', ':',          SO_U8,     2, 13, FLD_FUEL_BURNED,
+    SO_END
+};
+
+static const uint8_t PROGMEM kCockpit01S0Script[] = {
+    SO_LABEL,  0, 0, 4, 'R','P','M',':',   SO_U16,    4, 0, FLD_ENG_RPM,
+    SO_LABEL,  0, 1, 2, 'V', ':',          SO_SCALED, 2, 1, FLD_VOLTAGE,  5,
+    SO_LABEL,  0, 2, 3, 'T','1',':',       SO_U8,     3, 2, FLD_TEMP1,
+    SO_LABEL,  0, 3, 3, 'T','2',':',       SO_U8,     3, 3, FLD_TEMP2,
+    SO_LABEL,  0, 4, 3, 'T','3',':',       SO_U8,     3, 4, FLD_TEMP3,
+    SO_LABEL,  0, 5, 4, 'L','A','M',':',   SO_I8,     4, 5, FLD_LAMBDA,
+    SO_LABEL,  0, 6, 5, 'L','A','M','2',':', SO_I8,   5, 6, FLD_LAMBDA2,
+    SO_LABEL,  0, 7, 3, 'L','D',':',       SO_U16,    3, 7, FLD_ENG_LOAD,
+    SO_END
+};
+
+static const uint8_t PROGMEM kCockpit01S1Script[] = {
+    SO_LABEL,   0, 0, 4, 'T','B','a',':',  SO_SCALED, 4, 0, FLD_TB_ANGLE,    5,
+    SO_LABEL,   0, 1, 4, 'S','T','a',':',  SO_SCALED, 4, 1, FLD_STEER_ANGLE, 5,
+    SO_LABEL,   0, 2, 3, 'm','b', ':',     SO_U16,    3, 2, FLD_PRESSURE,
+    SO_LABEL,   0, 3, 5, 'b','i','t','s',':',
+    SO_STR,     0, 4, FLD_ERR_BITS_STR,
+    SO_END
+};
+// clang-format on
+
+void initCockpitScreen(DisplayManager& /*dm*/, uint8_t /*screen*/, uint8_t /*addrSelected*/) {}
 
 void renderCockpitScreen(DisplayManager& dm, uint8_t screen, uint8_t addrSelected,
                          const Model::OBDSignals& signals, bool forceUpdate)
 {
     using namespace Model;
 
-    char buf[11]; // Buffer for formatted strings (max 10 chars + null)
-
-    switch (addrSelected)
+    // Pre-assemble error bits string for screen 0x01/1 (const_cast is safe: bitsAsString
+    // is a mutable cache field, not logically const).
+    if (addrSelected == 0x01 && screen == 1)
     {
-        case 0x17:
+        if (signals.engine.errorBitsUpdated || forceUpdate)
         {
-            // Instruments cluster (address 0x17)
-            const InstrumentSignals& ins = signals.instruments;
-            const ComputedStats& c = signals.computed;
-            (void)screen;
-
-            // Row 0: SPD:XXX
-            buf[0] = 'S';
-            buf[1] = 'P';
-            buf[2] = 'D';
-            buf[3] = ':';
-            ltoa(ins.vehicleSpeed, buf + 4, 10);
-            dm.print(0, 0, buf);
-
-            // Row 1: RPM:XXXX
-            buf[0] = 'R';
-            buf[1] = 'P';
-            buf[2] = 'M';
-            buf[3] = ':';
-            ltoa(ins.engineRpm, buf + 4, 10);
-            dm.print(0, 1, buf);
-
-            // Row 2: CLT:XXX
-            buf[0] = 'C';
-            buf[1] = 'L';
-            buf[2] = 'T';
-            buf[3] = ':';
-            ltoa(ins.coolantTemp, buf + 4, 10);
-            dm.print(0, 2, buf);
-
-            // Row 3: OIL:XXX
-            buf[0] = 'O';
-            buf[1] = 'I';
-            buf[2] = 'L';
-            buf[3] = ':';
-            ltoa(ins.oilTemp, buf + 4, 10);
-            dm.print(0, 3, buf);
-
-            // Row 4: AMB:XXX
-            buf[0] = 'A';
-            buf[1] = 'M';
-            buf[2] = 'B';
-            buf[3] = ':';
-            ltoa(ins.ambientTemp, buf + 4, 10);
-            dm.print(0, 4, buf);
-
-            // Row 5: OL:X OP:X (abbreviated oil level + oil pressure)
-            buf[0] = 'O';
-            buf[1] = 'L';
-            buf[2] = ':';
-            buf[3] = '0' + ins.oilLevelOk;
-            buf[4] = ' ';
-            buf[5] = 'O';
-            buf[6] = 'P';
-            buf[7] = ':';
-            buf[8] = '0' + ins.oilPressureMin;
-            buf[9] = '\0';
-            dm.print(0, 5, buf);
-
-            // Row 6: ODO:XXXXXX
-            buf[0] = 'O';
-            buf[1] = 'D';
-            buf[2] = 'O';
-            buf[3] = ':';
-            ltoa(ins.odometer, buf + 4, 10);
-            dm.print(0, 6, buf);
-
-            // Row 7: FUL:XX
-            buf[0] = 'F';
-            buf[1] = 'U';
-            buf[2] = 'L';
-            buf[3] = ':';
-            ltoa(ins.fuelLevel, buf + 4, 10);
-            dm.print(0, 7, buf);
-
-            // Row 8: FSR:XXXXX
-            buf[0] = 'F';
-            buf[1] = 'S';
-            buf[2] = 'R';
-            buf[3] = ':';
-            ltoa(ins.fuelSensorResistance, buf + 4, 10);
-            dm.print(0, 8, buf);
-
-            // Row 9: TM:XXXXXXX
-            buf[0] = 'T';
-            buf[1] = 'M';
-            buf[2] = ':';
-            ltoa(ins.timeEcu, buf + 3, 10);
-            dm.print(0, 9, buf);
-
-            // Row 10: L100:X.X (fuel consumption per 100km, ×10 fixed-point)
-            dm.print(0, 10, F("L100:"));
-            dm.print(5, 10, (int32_t)c.fuelPer100km, 1, 5);
-
-            // Row 11: L/h:X.X (fuel consumption per hour, ×10 fixed-point)
-            dm.print(0, 11, F("L/h:"));
-            dm.print(4, 11, (int32_t)c.fuelPerHour, 1, 4);
-
-            // Row 12: km:XXXXX (distance since start)
-            buf[0] = 'k';
-            buf[1] = 'm';
-            buf[2] = ':';
-            ltoa(c.elapsedKmSinceStart, buf + 3, 10);
-            dm.print(0, 12, buf);
-
-            // Row 13: L:XX (fuel burned since start, integer litres)
-            dm.print(0, 13, F("L:"));
-            dm.print(2, 13, (int32_t)c.fuelBurnedSinceStart);
-
-            break;
-        }
-
-        case 0x01:
-        {
-            // Engine controller (address 0x01)
-            const EngineSignals& e = signals.engine;
-            const InstrumentSignals& ins = signals.instruments;
-
-            switch (screen)
-            {
-                case 0:
-                {
-                    // Row 0: RPM:XXXX
-                    buf[0] = 'R';
-                    buf[1] = 'P';
-                    buf[2] = 'M';
-                    buf[3] = ':';
-                    ltoa(ins.engineRpm, buf + 4, 10);
-                    dm.print(0, 0, buf);
-
-                    // Row 1: V:X.X (voltage ×10 fixed-point)
-                    dm.print(0, 1, F("V:"));
-                    dm.print(2, 1, (int32_t)e.voltage, 1, 5);
-
-                    // Row 2: T1:XXX
-                    buf[0] = 'T';
-                    buf[1] = '1';
-                    buf[2] = ':';
-                    ltoa(e.tempUnknown1, buf + 3, 10);
-                    dm.print(0, 2, buf);
-
-                    // Row 3: T2:XXX
-                    buf[0] = 'T';
-                    buf[1] = '2';
-                    buf[2] = ':';
-                    ltoa(e.tempUnknown2, buf + 3, 10);
-                    dm.print(0, 3, buf);
-
-                    // Row 4: T3:XXX
-                    buf[0] = 'T';
-                    buf[1] = '3';
-                    buf[2] = ':';
-                    ltoa(e.tempUnknown3, buf + 3, 10);
-                    dm.print(0, 4, buf);
-
-                    // Row 5: LAM:XXX
-                    buf[0] = 'L';
-                    buf[1] = 'A';
-                    buf[2] = 'M';
-                    buf[3] = ':';
-                    ltoa(e.lambda, buf + 4, 10);
-                    dm.print(0, 5, buf);
-
-                    // Row 6: LAM2:XXX
-                    buf[0] = 'L';
-                    buf[1] = 'A';
-                    buf[2] = 'M';
-                    buf[3] = '2';
-                    buf[4] = ':';
-                    ltoa(e.lambda2, buf + 5, 10);
-                    dm.print(0, 6, buf);
-
-                    // Row 7: LD:XXX (LOAD)
-                    buf[0] = 'L';
-                    buf[1] = 'D';
-                    buf[2] = ':';
-                    ltoa(e.engineLoad, buf + 3, 10);
-                    dm.print(0, 7, buf);
-
-                    break;
-                }
-
-                case 1:
-                {
-                    // Row 0: TBa:X.X (×10 fixed-point)
-                    dm.print(0, 0, F("TBa:"));
-                    dm.print(4, 0, (int32_t)e.tbAngle, 1, 5);
-
-                    // Row 1: STa:X.X (×10 fixed-point)
-                    dm.print(0, 1, F("STa:"));
-                    dm.print(4, 1, (int32_t)e.steeringAngle, 1, 5);
-
-                    // Row 2: mb:XXXX
-                    buf[0] = 'm';
-                    buf[1] = 'b';
-                    buf[2] = ':';
-                    ltoa(e.pressure, buf + 3, 10);
-                    dm.print(0, 2, buf);
-
-                    // Row 3: bits: (label)
-                    dm.print(0, 3, F("bits:"));
-
-                    // Row 4: error bit string (8 bits)
-                    EngineSignals& em = const_cast<EngineSignals&>(e);
-                    if (em.errorBitsUpdated || forceUpdate)
-                    {
-                        em.bitsAsString[0] = em.exhaustGasRecirculationError ? '1' : '0';
-                        em.bitsAsString[1] = em.oxygenSensorHeatingError ? '1' : '0';
-                        em.bitsAsString[2] = em.oxygenSensorError ? '1' : '0';
-                        em.bitsAsString[3] = em.airConditioningError ? '1' : '0';
-                        em.bitsAsString[4] = em.secondaryAirInjectionError ? '1' : '0';
-                        em.bitsAsString[5] = em.evaporativeEmissionsError ? '1' : '0';
-                        em.bitsAsString[6] = em.catalystHeatingError ? '1' : '0';
-                        em.bitsAsString[7] = em.catalyticConverter ? '1' : '0';
-                        em.bitsAsString[8] = '\0';
-                    }
-                    dm.print(0, 4, em.bitsAsString);
-
-                    break;
-                }
-
-                default:
-                {
-                    // Unknown screen fallback
-                    dm.print(0, 0, F("Screen"));
-                    ltoa((long)screen, buf, 10);
-                    dm.print(7, 0, buf);
-                    dm.print(0, 1, F("no data"));
-                    break;
-                }
-            }
-            break;
-        }
-
-        default:
-        {
-            // Unknown address fallback
-            dm.print(0, 0, F("Addr 0x"));
-            ltoa((long)addrSelected, buf, 16);
-            dm.print(7, 0, buf);
-            dm.print(0, 1, F("no data"));
-            break;
+            EngineSignals& em = const_cast<EngineSignals&>(signals.engine);
+            em.bitsAsString[0] = em.exhaustGasRecirculationError ? '1' : '0';
+            em.bitsAsString[1] = em.oxygenSensorHeatingError ? '1' : '0';
+            em.bitsAsString[2] = em.oxygenSensorError ? '1' : '0';
+            em.bitsAsString[3] = em.airConditioningError ? '1' : '0';
+            em.bitsAsString[4] = em.secondaryAirInjectionError ? '1' : '0';
+            em.bitsAsString[5] = em.evaporativeEmissionsError ? '1' : '0';
+            em.bitsAsString[6] = em.catalystHeatingError ? '1' : '0';
+            em.bitsAsString[7] = em.catalyticConverter ? '1' : '0';
+            em.bitsAsString[8] = '\0';
         }
     }
+
+    ScreenCtx ctx{&signals, nullptr, 0, 0};
+    const uint8_t* script = nullptr;
+
+    if (addrSelected == 0x17)
+    {
+        script = kCockpit17Script;
+    }
+    else if (addrSelected == 0x01)
+    {
+        script = (screen == 0) ? kCockpit01S0Script : kCockpit01S1Script;
+    }
+
+    if (script)
+    {
+        runScript(script, ctx, dm);
+    }
+    else
+    {
+        char buf[4];
+        dm.print(0, 0, F("Addr 0x"));
+        ltoa((long)addrSelected, buf, 16);
+        dm.print(7, 0, buf);
+        dm.print(0, 1, F("no data"));
+    }
+
+    (void)forceUpdate;
 }
 
 } // namespace Display

--- a/src/obd/Display/screens/DTCScreen.cpp
+++ b/src/obd/Display/screens/DTCScreen.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "DTCScreen.h"
+#include "../ScreenVM.h"
 
 namespace obd
 {
@@ -25,6 +26,16 @@ namespace Display
 //   Row 12:    S:XXX
 //   Row 14: U/D:pg Sel:bk
 
+// clang-format off
+static const uint8_t PROGMEM kDtcMenuScript[] = {
+    SO_LABEL,  0,  0, 8, 'D','T','C',' ','M','e','n','u',
+    SO_CURSOR, 0,  2, 0, 4, 'R','e','a','d',
+    SO_CURSOR, 0,  4, 1, 5, 'C','l','e','a','r',
+    SO_CURSOR, 0,  6, 2, 4, 'S','h','o','w',
+    SO_END
+};
+// clang-format on
+
 static const uint8_t rowV[4] = {2, 5, 8, 11};
 static const uint8_t rowS[4] = {3, 6, 9, 12};
 
@@ -35,15 +46,11 @@ void renderDtcScreen(DisplayManager& dm, uint8_t cursor, bool showActive, uint8_
 
     if (!showActive)
     {
-        // ── Main menu ───────────────────────────────────────────────
-        dm.print(0, 0, F("DTC Menu"));
+        // ── Main menu (VM-rendered) ──────────────────────────────────
+        ScreenCtx ctx{nullptr, nullptr, cursor, 0};
+        runScript(kDtcMenuScript, ctx, dm);
 
-        // Three selectable actions with '>' cursor indicator
-        dm.print(0, 2, cursor == 0 ? F(">Read") : F(" Read"));
-        dm.print(0, 4, cursor == 1 ? F(">Clear") : F(" Clear"));
-        dm.print(0, 6, cursor == 2 ? F(">Show") : F(" Show"));
-
-        // DTC count at the bottom
+        // DTC count line: "--" until first read, number after
         dm.print(0, 14, F("DTCs:"));
         if (dtcCount < 0)
         {

--- a/src/obd/Display/screens/DebugScreen.cpp
+++ b/src/obd/Display/screens/DebugScreen.cpp
@@ -1,76 +1,35 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "DebugScreen.h"
+#include "../ScreenVM.h"
 
 namespace obd
 {
 namespace Display
 {
 
-// Debug layout (10 cols × 16 rows):
-//   Row 0:  Con: 1        (NewSoftwareSerial isListening)
-//   Row 1:  Ava: 0        (bytes available in RX buffer)
-//   Row 2:  BC: 42        (KWP block counter)
-//   Row 3:  KWP: Sensor   (mode name)
-//   Row 4:  Grp: 3        (current KWP group)
-//   Row 5:  Adr: 0x17     (ECU address)
-//   Row 6:  Baud:9600     (baud rate)
-//   Row 7:  Att: 0        (connection attempts)
-//   Row 8:  Sim: N        (simulation mode active)
-//   Row 9:  RAM: 834      (estimated free RAM bytes)
+// clang-format off
+static const uint8_t PROGMEM kDebugScript[] = {
+    SO_LABEL,  0, 0, 4, 'C','o','n',':',   SO_U8,      4, 0, FLD_DBG_CON,
+    SO_LABEL,  0, 1, 4, 'A','v','a',':',   SO_U8,      4, 1, FLD_DBG_AVA,
+    SO_LABEL,  0, 2, 3, 'B','C', ':',      SO_U8,      3, 2, FLD_DBG_BC,
+    SO_LABEL,  0, 3, 4, 'K','W','P',':',   SO_MODE_STR, 4, 3, FLD_KWP_MODE,
+    SO_LABEL,  0, 4, 4, 'G','r','p',':',   SO_U8,      4, 4, FLD_DBG_GRP,
+    SO_LABEL,  0, 5, 4, 'A','d','r',':',   SO_HEX_U8,  4, 5, FLD_DBG_ADDR,
+    SO_LABEL,  0, 6, 5, 'B','a','u','d',':', SO_U16,   5, 6, FLD_DBG_BAUD,
+    SO_LABEL,  0, 7, 4, 'A','t','t',':',   SO_U8,      4, 7, FLD_DBG_ATT,
+    SO_LABEL,  0, 8, 4, 'S','i','m',':',   SO_BOOL_YN, 4, 8, FLD_DBG_SIM,
+    SO_LABEL,  0, 9, 4, 'R','A','M',':',   SO_U16,     4, 9, FLD_DBG_RAM,
+    SO_END
+};
+// clang-format on
 
 void initDebugScreen(DisplayManager& /*dm*/) {}
 
 void renderDebugScreen(const DisplayManager& dm, const DebugInfo& di, int kwpModeInt)
 {
 #ifdef OBD_EXPERIMENTAL_SCREENS
-    char buf[7];
-
-    dm.print(0, 0, F("Con:"));
-    dm.print(4, 0, (int32_t)di.serialCon);
-
-    dm.print(0, 1, F("Ava:"));
-    dm.print(4, 1, (int32_t)di.serialAva);
-
-    dm.print(0, 2, F("BC:"));
-    dm.print(3, 2, (int32_t)di.blockCtr);
-
-    dm.print(0, 3, F("KWP:"));
-    switch (kwpModeInt)
-    {
-        case 0:
-            dm.print(4, 3, F("ACK"));
-            break;
-        case 2:
-            dm.print(4, 3, F("Grp"));
-            break;
-        default:
-            dm.print(4, 3, F("Sensor"));
-            break;
-    }
-
-    dm.print(0, 4, F("Grp:"));
-    dm.print(4, 4, (int32_t)di.group);
-
-    // Address as "0xNN"
-    dm.print(0, 5, F("Adr:"));
-    buf[0] = '0';
-    buf[1] = 'x';
-    ltoa((long)di.addr, buf + 2, 16);
-    dm.print(4, 5, buf);
-
-    dm.print(0, 6, F("Baud:"));
-    dm.print(5, 6, (int32_t)di.baud);
-
-    dm.print(0, 7, F("Att:"));
-    dm.print(4, 7, (int32_t)di.attempts);
-
-    dm.print(0, 8, F("Sim:"));
-    dm.print(4, 8, di.sim ? F("Y") : F("N"));
-
-    dm.print(0, 9, F("RAM:"));
-    dm.print(4, 9, (int32_t)di.freeRam);
-
-    (void)buf;
+    ScreenCtx ctx{nullptr, &di, 0, (uint8_t)kwpModeInt};
+    runScript(kDebugScript, ctx, dm);
 #else
     (void)dm;
     (void)di;

--- a/src/obd/Display/screens/ExperimentalScreen.cpp
+++ b/src/obd/Display/screens/ExperimentalScreen.cpp
@@ -1,70 +1,36 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "ExperimentalScreen.h"
-#include "ScreenHelpers.h"
+#include "../ScreenVM.h"
 
 namespace obd
 {
 namespace Display
 {
 
-// Portrait layout (10 cols x 16 rows):
-//   Row  0: Grp: XX
-//   Row  1: (empty)
-//   Row  2: V1: XXXXXXX
-//   Row  3: U1: UUUUUU
-//   Row  4: (empty)
-//   Row  5: V2: XXXXXXX
-//   Row  6: U2: UUUUUU
-//   Row  7: (empty)
-//   Row  8: V3: XXXXXXX
-//   Row  9: U3: UUUUUU
-//   Row 10: (empty)
-//   Row 11: V4: XXXXXXX
-//   Row 12: U4: UUUUUU
+// clang-format off
+static const uint8_t PROGMEM kExpScript[] = {
+    SO_LABEL,  0,  0, 4, 'G','r','p',':',  SO_U8,     5,  0, FLD_EXP_GRP,
+    SO_LABEL,  0,  2, 3, 'V','1',':',      SO_SCALED, 3,  2, FLD_EXP_V0, 7,
+    SO_LABEL,  0,  3, 3, 'U','1',':',      SO_STR,    3,  3, FLD_EXP_U0,
+    SO_LABEL,  0,  5, 3, 'V','2',':',      SO_SCALED, 3,  5, FLD_EXP_V1, 7,
+    SO_LABEL,  0,  6, 3, 'U','2',':',      SO_STR,    3,  6, FLD_EXP_U1,
+    SO_LABEL,  0,  8, 3, 'V','3',':',      SO_SCALED, 3,  8, FLD_EXP_V2, 7,
+    SO_LABEL,  0,  9, 3, 'U','3',':',      SO_STR,    3,  9, FLD_EXP_U2,
+    SO_LABEL,  0, 11, 3, 'V','4',':',      SO_SCALED, 3, 11, FLD_EXP_V3, 7,
+    SO_LABEL,  0, 12, 3, 'U','4',':',      SO_STR,    3, 12, FLD_EXP_U3,
+    SO_END
+};
+// clang-format on
 
-void initExperimentalScreen(DisplayManager& /*dm*/)
-{
-    // No-op: all rendering is done in renderExperimentalScreen
-}
+void initExperimentalScreen(DisplayManager& /*dm*/) {}
 
 void renderExperimentalScreen(const DisplayManager& dm, uint8_t /*screen*/,
                               const Model::OBDSignals& signals, bool forceUpdate)
 {
 #ifdef OBD_EXPERIMENTAL_SCREENS
-    const Model::ExperimentalGroup& eg = signals.experimental;
-
-    char buf[11];
-
-    // Row 0: Grp: XX
-    dm.print(0, 0, F("Grp:"));
-    ltoa((long)eg.groupCurrent, buf, 10);
-    dm.print(5, 0, buf);
-
-    // Slot 1 (rows 2-3) — v[n] is ×10 fixed-point
-    dm.print(0, 2, F("V1:"));
-    dm.print(3, 2, eg.v[0], 1, 7);
-    dm.print(0, 3, F("U1:"));
-    dm.print(3, 3, eg.unit[0]);
-
-    // Slot 2 (rows 5-6)
-    dm.print(0, 5, F("V2:"));
-    dm.print(3, 5, eg.v[1], 1, 7);
-    dm.print(0, 6, F("U2:"));
-    dm.print(3, 6, eg.unit[1]);
-
-    // Slot 3 (rows 8-9)
-    dm.print(0, 8, F("V3:"));
-    dm.print(3, 8, eg.v[2], 1, 7);
-    dm.print(0, 9, F("U3:"));
-    dm.print(3, 9, eg.unit[2]);
-
-    // Slot 4 (rows 11-12)
-    dm.print(0, 11, F("V4:"));
-    dm.print(3, 11, eg.v[3], 1, 7);
-    dm.print(0, 12, F("U4:"));
-    dm.print(3, 12, eg.unit[3]);
-
     (void)forceUpdate;
+    ScreenCtx ctx{&signals, nullptr, 0, 0};
+    runScript(kExpScript, ctx, dm);
 #else
     (void)dm;
     (void)signals;

--- a/src/obd/Display/screens/ExperimentalScreen.cpp
+++ b/src/obd/Display/screens/ExperimentalScreen.cpp
@@ -40,27 +40,27 @@ void renderExperimentalScreen(const DisplayManager& dm, uint8_t /*screen*/,
     ltoa((long)eg.groupCurrent, buf, 10);
     dm.print(5, 0, buf);
 
-    // Slot 1 (rows 2-3)
+    // Slot 1 (rows 2-3) — v[n] is ×10 fixed-point
     dm.print(0, 2, F("V1:"));
-    dm.print(3, 2, eg.v[0], 7);
+    dm.print(3, 2, eg.v[0], 1, 7);
     dm.print(0, 3, F("U1:"));
     dm.print(3, 3, eg.unit[0]);
 
     // Slot 2 (rows 5-6)
     dm.print(0, 5, F("V2:"));
-    dm.print(3, 5, eg.v[1], 7);
+    dm.print(3, 5, eg.v[1], 1, 7);
     dm.print(0, 6, F("U2:"));
     dm.print(3, 6, eg.unit[1]);
 
     // Slot 3 (rows 8-9)
     dm.print(0, 8, F("V3:"));
-    dm.print(3, 8, eg.v[2], 7);
+    dm.print(3, 8, eg.v[2], 1, 7);
     dm.print(0, 9, F("U3:"));
     dm.print(3, 9, eg.unit[2]);
 
     // Slot 4 (rows 11-12)
     dm.print(0, 11, F("V4:"));
-    dm.print(3, 11, eg.v[3], 7);
+    dm.print(3, 11, eg.v[3], 1, 7);
     dm.print(0, 12, F("U4:"));
     dm.print(3, 12, eg.unit[3]);
 

--- a/src/obd/Display/screens/ScreenHelpers.h
+++ b/src/obd/Display/screens/ScreenHelpers.h
@@ -29,13 +29,12 @@ static inline void printField(const DisplayManager& dm, uint8_t x, uint8_t y, T 
     updated = false;
 }
 
-static inline void printFieldFloat(const DisplayManager& dm, uint8_t x, uint8_t y, float value,
-                                   uint8_t width, bool& updated, bool forceUpdate)
+static inline void printFieldScaled(const DisplayManager& dm, uint8_t x, uint8_t y, int32_t value,
+                                    uint8_t width, bool& updated, bool forceUpdate)
 {
     if (!(updated || forceUpdate))
         return;
-    // With text-only rendering, entries are always cleared before render.
-    dm.print(x, y, value, width);
+    dm.print(x, y, value, 1, width);
     updated = false;
 }
 

--- a/src/obd/Display/screens/SettingsScreen.cpp
+++ b/src/obd/Display/screens/SettingsScreen.cpp
@@ -1,36 +1,27 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "SettingsScreen.h"
+#include "../ScreenVM.h"
 
 namespace obd
 {
 namespace Display
 {
 
-// Settings layout (10 cols × 16 rows):
-//   Row 0:  Settings
-//   Row 2:  [>] Exit
-//   Row 4:  [ ] KWP: Sensor   (shows current mode)
+// clang-format off
+static const uint8_t PROGMEM kSettingsScript[] = {
+    SO_LABEL,    0, 0, 8, 'S','e','t','t','i','n','g','s',
+    SO_CURSOR,   0, 2, 0, 4, 'E','x','i','t',
+    SO_CURSOR,   0, 4, 1, 4, 'K','W','P',':',
+    SO_MODE_STR, 5, 4, FLD_KWP_MODE,
+    SO_END
+};
+// clang-format on
 
 void renderSettingsScreen(DisplayManager& dm, uint8_t cursor, int kwpModeInt)
 {
-    dm.print(0, 0, F("Settings"));
-
-    dm.print(0, 2, cursor == 0 ? F(">Exit") : F(" Exit"));
-
-    // KWP mode row — show the current mode name inline
-    dm.print(0, 4, cursor == 1 ? F(">KWP:") : F(" KWP:"));
-    switch (kwpModeInt)
-    {
-        case 0:
-            dm.print(5, 4, F("ACK"));
-            break;
-        case 2:
-            dm.print(5, 4, F("Grp"));
-            break;
-        default:
-            dm.print(5, 4, F("Sens"));
-            break;
-    }
+    ScreenCtx ctx{nullptr, nullptr, cursor, (uint8_t)kwpModeInt};
+    runScript(kSettingsScript, ctx, dm);
+    (void)dm;
 }
 
 } // namespace Display

--- a/src/obd/Display/screens/SettingsScreen.cpp
+++ b/src/obd/Display/screens/SettingsScreen.cpp
@@ -17,11 +17,10 @@ static const uint8_t PROGMEM kSettingsScript[] = {
 };
 // clang-format on
 
-void renderSettingsScreen(DisplayManager& dm, uint8_t cursor, int kwpModeInt)
+void renderSettingsScreen(const DisplayManager& dm, uint8_t cursor, int kwpModeInt)
 {
     ScreenCtx ctx{nullptr, nullptr, cursor, (uint8_t)kwpModeInt};
     runScript(kSettingsScript, ctx, dm);
-    (void)dm;
 }
 
 } // namespace Display

--- a/src/obd/Display/screens/SettingsScreen.h
+++ b/src/obd/Display/screens/SettingsScreen.h
@@ -9,7 +9,7 @@ namespace Display
 {
 
 // Settings: single screen, up/down cursor selects Exit (0) or KWP Mode (1).
-void renderSettingsScreen(DisplayManager& dm, uint8_t cursor, int kwpModeInt);
+void renderSettingsScreen(const DisplayManager& dm, uint8_t cursor, int kwpModeInt);
 
 } // namespace Display
 } // namespace obd

--- a/src/obd/Input/ButtonInput.cpp
+++ b/src/obd/Input/ButtonInput.cpp
@@ -42,41 +42,22 @@ bool ButtonInput::update(MenuState& menuState, const InputActions& actions)
         switch (menuState.currentMenu())
         {
             case MenuId::Cockpit:
-                if (readUp())
-                {
-                    menuState.nextCockpitScreen();
-                    any = true;
-                }
-                else if (readDown())
-                {
-                    menuState.prevCockpitScreen();
-                    any = true;
-                }
-                break;
             case MenuId::Experimental:
-                if (readUp())
-                {
-                    menuState.nextExperimentalScreen();
-                    any = true;
-                }
-                else if (readDown())
-                {
-                    menuState.prevExperimentalScreen();
-                    any = true;
-                }
-                break;
             case MenuId::Debug:
+            {
+                MenuId mid = menuState.currentMenu();
                 if (readUp())
                 {
-                    menuState.nextDebugScreen();
+                    menuState.nextScreen(mid);
                     any = true;
                 }
                 else if (readDown())
                 {
-                    menuState.prevDebugScreen();
+                    menuState.prevScreen(mid);
                     any = true;
                 }
                 break;
+            }
             case MenuId::Dtc:
             case MenuId::Settings:
                 // DTC and Settings navigation is handled entirely by

--- a/src/obd/Input/MenuState.cpp
+++ b/src/obd/Input/MenuState.cpp
@@ -7,11 +7,13 @@ namespace Input
 {
 
 MenuState::MenuState()
-    : currentMenu_(Display::MenuId::Cockpit), cockpitScreen_(0), cockpitScreenMax_(1),
-      experimentalScreen_(0), experimentalScreenMax_(64), debugScreen_(0), debugScreenMax_(4),
-      dtcScreen_(0), dtcScreenMax_(0), settingsScreen_(0), settingsScreenMax_(0),
-      menuChanged_(false), screenChanged_(false)
+    : currentMenu_(Display::MenuId::Cockpit), menuChanged_(false), screenChanged_(false)
 {
+    screens_[0] = {0, 1};  // Cockpit: max 1
+    screens_[1] = {0, 64}; // Experimental: max 64
+    screens_[2] = {0, 4};  // Debug: max 4
+    screens_[3] = {0, 0};  // Dtc: max 0
+    screens_[4] = {0, 0};  // Settings: max 0
 }
 
 void MenuState::nextMenu()
@@ -33,51 +35,21 @@ void MenuState::prevMenu()
     menuChanged_ = true;
 }
 
-void MenuState::nextCockpitScreen()
+void MenuState::nextScreen(Display::MenuId id)
 {
-    if (++cockpitScreen_ > cockpitScreenMax_)
-        cockpitScreen_ = 0;
+    NavCtx& c = screens_[static_cast<uint8_t>(id)];
+    if (++c.current > c.max)
+        c.current = 0;
     screenChanged_ = true;
 }
 
-void MenuState::prevCockpitScreen()
+void MenuState::prevScreen(Display::MenuId id)
 {
-    if (cockpitScreen_ == 0)
-        cockpitScreen_ = cockpitScreenMax_;
+    NavCtx& c = screens_[static_cast<uint8_t>(id)];
+    if (c.current == 0)
+        c.current = c.max;
     else
-        --cockpitScreen_;
-    screenChanged_ = true;
-}
-
-void MenuState::nextExperimentalScreen()
-{
-    if (++experimentalScreen_ > experimentalScreenMax_)
-        experimentalScreen_ = 0;
-    screenChanged_ = true;
-}
-
-void MenuState::prevExperimentalScreen()
-{
-    if (experimentalScreen_ == 0)
-        experimentalScreen_ = experimentalScreenMax_;
-    else
-        --experimentalScreen_;
-    screenChanged_ = true;
-}
-
-void MenuState::nextDebugScreen()
-{
-    if (++debugScreen_ > debugScreenMax_)
-        debugScreen_ = 0;
-    screenChanged_ = true;
-}
-
-void MenuState::prevDebugScreen()
-{
-    if (debugScreen_ == 0)
-        debugScreen_ = debugScreenMax_;
-    else
-        --debugScreen_;
+        --c.current;
     screenChanged_ = true;
 }
 

--- a/src/obd/Input/MenuState.h
+++ b/src/obd/Input/MenuState.h
@@ -15,23 +15,18 @@ class MenuState
     MenuState();
 
     Display::MenuId currentMenu() const { return currentMenu_; }
-    uint8_t cockpitScreen() const { return cockpitScreen_; }
-    uint8_t experimentalScreen() const { return experimentalScreen_; }
-    void setExperimentalScreen(uint8_t v) { experimentalScreen_ = v; }
-    uint8_t debugScreen() const { return debugScreen_; }
-    uint8_t dtcScreen() const { return dtcScreen_; }
-    uint8_t settingsScreen() const { return settingsScreen_; }
-    void setSettingsScreen(uint8_t v) { settingsScreen_ = v; }
+
+    uint8_t screen(Display::MenuId id) const { return screens_[static_cast<uint8_t>(id)].current; }
+    void setScreen(Display::MenuId id, uint8_t v)
+    {
+        screens_[static_cast<uint8_t>(id)].current = v;
+    }
 
     void nextMenu();
     void prevMenu();
+    void nextScreen(Display::MenuId id);
+    void prevScreen(Display::MenuId id);
 
-    void nextCockpitScreen();
-    void prevCockpitScreen();
-    void nextExperimentalScreen();
-    void prevExperimentalScreen();
-    void nextDebugScreen();
-    void prevDebugScreen();
     bool consumeMenuChanged();
     bool consumeScreenChanged();
 
@@ -39,23 +34,14 @@ class MenuState
     void markScreenChanged();
 
   private:
+    struct NavCtx
+    {
+        uint8_t current;
+        uint8_t max;
+    };
+
     Display::MenuId currentMenu_;
-
-    uint8_t cockpitScreen_;
-    uint8_t cockpitScreenMax_;
-
-    uint8_t experimentalScreen_;
-    uint8_t experimentalScreenMax_;
-
-    uint8_t debugScreen_;
-    uint8_t debugScreenMax_;
-
-    uint8_t dtcScreen_;
-    uint8_t dtcScreenMax_;
-
-    uint8_t settingsScreen_;
-    uint8_t settingsScreenMax_;
-
+    NavCtx screens_[5]; // indexed by static_cast<uint8_t>(MenuId)
     bool menuChanged_;
     bool screenChanged_;
 };

--- a/src/obd/KWP/KWP1281Session.cpp
+++ b/src/obd/KWP/KWP1281Session.cpp
@@ -532,17 +532,18 @@ bool KWP1281Session::readSensorsGroup(uint8_t group, Model::OBDSignals& signals)
                         signals.instruments.engineRpmUpdated = true;
                     }
 
-                    uint8_t cool = (uint8_t)(s[7] * (s[8] - 100) * 0.1f);
+                    uint8_t cool = (uint8_t)((int16_t)s[7] * ((int16_t)s[8] - 100) / 10);
                     if (signals.instruments.coolantTemp != cool)
                     {
                         signals.instruments.coolantTemp = cool;
                         signals.instruments.coolantTempUpdated = true;
                     }
 
-                    float volt = 0.001f * s[10] * s[11];
-                    if (signals.engine.voltage != volt)
+                    // voltage stored ×10 (0.1V units): 0.001*a*b*10 = a*b/100
+                    uint16_t volt_x10 = (uint16_t)s[10] * s[11] / 100;
+                    if (signals.engine.voltage != volt_x10)
                     {
-                        signals.engine.voltage = volt;
+                        signals.engine.voltage = volt_x10;
                         signals.engine.voltageUpdated = true;
                     }
                     break;

--- a/src/obd/KWP/KWPSensorDecode.cpp
+++ b/src/obd/KWP/KWPSensorDecode.cpp
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "KWPSensorDecode.h"
 #include <avr/pgmspace.h>
-#include <string.h> // memcpy_P
 
 namespace obd
 {
@@ -38,165 +37,257 @@ enum FormulaType : uint8_t
     F_ABS_BK_CA,
     F_B,
     F_B_A,
-    F_AK_B,
-    F_B_AK,
+    F_AK_B, // v = a*c1 + b  (F_B_AK merged here: b+a*c1 is identical)
     F_LINEAR,
     F_SPECIAL,
 };
 
+// c2_idx values (bits[7:4] of typeAndC2) → actual c2 for BK_CA formula types.
+static const uint8_t kC2[4] PROGMEM = {0, 100, 127, 128};
+
 struct __attribute__((packed)) KWPEntry
 {
-    FormulaType type;
-    float c1;
-    float c2;
-    float c3;
+    uint8_t typeAndC2; // bits[3:0]=FormulaType, bits[7:4]=c2_idx
+    int16_t c1_s;      // c1 × 1000 (e.g. 0.2 → 200, 1.421 → 1421)
 };
 
+// 57 entries × 3 bytes = 171 bytes  (was 741 bytes with 3 floats each)
+// c1_s = c1 × 1000 stored as int16_t.
+// k=20,23,31,39,41,48,51,54,56 → F_SPECIAL (non-power-of-2 or large c1, handled in switch).
+// k=25,40,42,43,53 → F_LINEAR (handled in computeFormula with hardcoded integer c2/c3).
 static const KWPEntry kwp_table[57] PROGMEM = {
-    /* 0  unused */ {F_SPECIAL, 0, 0, 0},
-    /* 1  rpm    */ {F_AB_C, 0.2f, 0, 0},
-    /* 2  %%     */ {F_AB_C, 0.002f, 0, 0},
-    /* 3  Deg    */ {F_AB_C, 0.002f, 0, 0},
-    /* 4  ATDC   */ {F_ABS_BK_CA, 0.01f, 127, 0},
-    /* 5  °C     */ {F_BK_CA, 0.1f, 100, 0},
-    /* 6  V      */ {F_AB_C, 0.001f, 0, 0},
-    /* 7  km/h   */ {F_AB_C, 0.01f, 0, 0},
-    /* 8  raw    */ {F_AB_C, 0.1f, 0, 0},
-    /* 9  Deg    */ {F_BK_CA, 0.02f, 127, 0},
-    /* 10 WARM   */ {F_SPECIAL, 0, 0, 0},
-    /* 11 lambda */ {F_SPECIAL, 0, 0, 0},
-    /* 12 Ohm    */ {F_AB_C, 0.001f, 0, 0},
-    /* 13 mm     */ {F_BK_CA, 0.001f, 127, 0},
-    /* 14 bar    */ {F_AB_C, 0.005f, 0, 0},
-    /* 15 ms     */ {F_AB_C, 0.01f, 0, 0},
-    /* 16 unused */ {F_SPECIAL, 0, 0, 0},
-    /* 17 unused */ {F_SPECIAL, 0, 0, 0},
-    /* 18 mbar   */ {F_AB_C, 0.04f, 0, 0},
-    /* 19 l      */ {F_AB_C, 0.01f, 0, 0},
-    /* 20 %%     */ {F_BK_CA, 0.0078125f, 128, 0},
-    /* 21 V      */ {F_AB_C, 0.001f, 0, 0},
-    /* 22 ms     */ {F_AB_C, 0.001f, 0, 0},
-    /* 23 %%     */ {F_AB_C, 0.00390625f, 0, 0},
-    /* 24 A      */ {F_AB_C, 0.001f, 0, 0},
-    /* 25 g/s    */ {F_LINEAR, 1.421f, 0.005494f, 0},
-    /* 26 C      */ {F_B_A, 0, 0, 0},
-    /* 27 °      */ {F_ABS_BK_CA, 0.01f, 128, 0},
-    /* 28 raw    */ {F_B_A, 0, 0, 0},
-    /* 29 unused */ {F_SPECIAL, 0, 0, 0},
-    /* 30 Dk/w   */ {F_AB_C, 0.083333f, 0, 0},
-    /* 31 °C     */ {F_AB_C, 0.000390625f, 0, 0},
-    /* 32 unused */ {F_SPECIAL, 0, 0, 0},
-    /* 33 %%     */ {F_SPECIAL, 0, 0, 0},
-    /* 34 kW     */ {F_BK_CA, 0.01f, 128, 0},
-    /* 35 l/h    */ {F_AB_C, 0.01f, 0, 0},
-    /* 36 km     */ {F_SPECIAL, 0, 0, 0},
-    /* 37 raw    */ {F_B, 0, 0, 0},
-    /* 38 Dk/w   */ {F_BK_CA, 0.001f, 128, 0},
-    /* 39 mg/h   */ {F_AB_C, 0.00390625f, 0, 0},
-    /* 40 A      */ {F_LINEAR, 0.1f, 25.5f, -400.0f},
-    /* 41 Ah     */ {F_B_AK, 255.0f, 0, 0},
-    /* 42 Kw     */ {F_LINEAR, 0.1f, 25.5f, -400.0f},
-    /* 43 V      */ {F_LINEAR, 0.1f, 25.5f, 0},
-    /* 44 unused */ {F_SPECIAL, 0, 0, 0},
-    /* 45 raw    */ {F_AB_C, 0.001f, 0, 0},
-    /* 46 Dk/w   */ {F_SPECIAL, 0, 0, 0},
-    /* 47 ms     */ {F_BK_CA, 1.0f, 128, 0},
-    /* 48 raw    */ {F_B_AK, 255.0f, 0, 0},
-    /* 49 mg/h   */ {F_AB_C, 0.025f, 0, 0},
-    /* 50 mbar   */ {F_SPECIAL, 0, 0, 0},
-    /* 51 mg/h   */ {F_BK_CA, 0.003922f, 128, 0},
-    /* 52 Nm     */ {F_SPECIAL, 0, 0, 0},
-    /* 53 g/s    */ {F_LINEAR, 1.4222f, 0.006f, -182.04f},
-    /* 54 count  */ {F_AK_B, 256.0f, 0, 0},
-    /* 55 s      */ {F_AB_C, 0.005f, 0, 0},
-    /* 56 raw    */ {F_AK_B, 256.0f, 0, 0},
+    /* 0  unused */ {F_SPECIAL, 0},
+    /* 1  rpm    */ {F_AB_C, 200},                // 0.2
+    /* 2  %%     */ {F_AB_C, 2},                  // 0.002
+    /* 3  Deg    */ {F_AB_C, 2},                  // 0.002
+    /* 4  ATDC   */ {(2 << 4) | F_ABS_BK_CA, 10}, // 0.01, c2=127
+    /* 5  °C     */ {(1 << 4) | F_BK_CA, 100},    // 0.1,  c2=100
+    /* 6  V      */ {F_AB_C, 1},                  // 0.001
+    /* 7  km/h   */ {F_AB_C, 10},                 // 0.01
+    /* 8  raw    */ {F_AB_C, 100},                // 0.1
+    /* 9  Deg    */ {(2 << 4) | F_BK_CA, 20},     // 0.02, c2=127
+    /* 10 WARM   */ {F_SPECIAL, 0},
+    /* 11 lambda */ {F_SPECIAL, 0},
+    /* 12 Ohm    */ {F_AB_C, 1},             // 0.001
+    /* 13 mm     */ {(2 << 4) | F_BK_CA, 1}, // 0.001, c2=127
+    /* 14 bar    */ {F_AB_C, 5},             // 0.005
+    /* 15 ms     */ {F_AB_C, 10},            // 0.01
+    /* 16 unused */ {F_SPECIAL, 0},
+    /* 17 unused */ {F_SPECIAL, 0},
+    /* 18 mbar   */ {F_AB_C, 40},     // 0.04
+    /* 19 l      */ {F_AB_C, 10},     // 0.01
+    /* 20 %%     */ {F_SPECIAL, 0},   // c1=1/128, handled as special
+    /* 21 V      */ {F_AB_C, 1},      // 0.001
+    /* 22 ms     */ {F_AB_C, 1},      // 0.001
+    /* 23 %%     */ {F_SPECIAL, 0},   // c1=1/256, handled as special
+    /* 24 A      */ {F_AB_C, 1},      // 0.001
+    /* 25 g/s    */ {F_LINEAR, 1421}, // 1.421, c2/c3 hardcoded in dispatch
+    /* 26 C      */ {F_B_A, 0},
+    /* 27 °      */ {(3 << 4) | F_ABS_BK_CA, 10}, // 0.01, c2=128
+    /* 28 raw    */ {F_B_A, 0},
+    /* 29 unused */ {F_SPECIAL, 0},
+    /* 30 Dk/w   */ {F_AB_C, 83},   // 0.083333 ≈ 83/1000
+    /* 31 °C     */ {F_SPECIAL, 0}, // c1=1/2560, handled as special
+    /* 32 unused */ {F_SPECIAL, 0},
+    /* 33 %%     */ {F_SPECIAL, 0},
+    /* 34 kW     */ {(3 << 4) | F_BK_CA, 10}, // 0.01, c2=128
+    /* 35 l/h    */ {F_AB_C, 10},             // 0.01
+    /* 36 km     */ {F_SPECIAL, 0},
+    /* 37 raw    */ {F_B, 0},
+    /* 38 Dk/w   */ {(3 << 4) | F_BK_CA, 1}, // 0.001, c2=128
+    /* 39 mg/h   */ {F_SPECIAL, 0},          // c1=1/256, handled as special
+    /* 40 A      */ {F_LINEAR, 100},         // 0.1, c2/c3 hardcoded
+    /* 41 Ah     */ {F_SPECIAL, 0},          // v=255*a+b, handled as special
+    /* 42 Kw     */ {F_LINEAR, 100},         // 0.1, c2/c3 hardcoded
+    /* 43 V      */ {F_LINEAR, 100},         // 0.1, c2/c3 hardcoded
+    /* 44 unused */ {F_SPECIAL, 0},
+    /* 45 raw    */ {F_AB_C, 1}, // 0.001
+    /* 46 Dk/w   */ {F_SPECIAL, 0},
+    /* 47 ms     */ {(3 << 4) | F_BK_CA, 1000}, // 1.0, c2=128
+    /* 48 raw    */ {F_SPECIAL, 0},             // v=255*a+b, handled as special
+    /* 49 mg/h   */ {F_AB_C, 25},               // 0.025
+    /* 50 mbar   */ {F_SPECIAL, 0},
+    /* 51 mg/h   */ {F_SPECIAL, 0}, // c1≈1/255, handled as special
+    /* 52 Nm     */ {F_SPECIAL, 0},
+    /* 53 g/s    */ {F_LINEAR, 1422}, // 1.4222, c2/c3 hardcoded
+    /* 54 count  */ {F_SPECIAL, 0},   // v=256*a+b, handled as special
+    /* 55 s      */ {F_AB_C, 5},      // 0.005
+    /* 56 raw    */ {F_SPECIAL, 0},   // v=256*a+b, handled as special
 };
-
-// Read a float from a packed PROGMEM address (handles unaligned access safely).
-static float pgmFloat(const float* addr)
-{
-    float f;
-    memcpy_P(&f, addr, sizeof(float));
-    return f;
-}
 
 // Apply the tabulated formula for measurement type k.
-static float computeFormula(uint8_t k, byte a, byte b)
+// Returns value ×10 as int32_t (e.g. 1230 = 123.0).
+static int32_t computeFormula(uint8_t k, byte a, byte b)
 {
     const KWPEntry* e = &kwp_table[k];
-    switch ((FormulaType)pgm_read_byte(&e->type))
+    uint8_t raw = pgm_read_byte(&e->typeAndC2);
+    FormulaType t = (FormulaType)(raw & 0x0F);
+    int16_t c1s = (int16_t)pgm_read_word(&e->c1_s);
+
+    // All formulae: v_x10 = (c1_s/1000) * formula_result * 10
+    //             = c1_s * formula_result / 100
+    switch (t)
     {
         case F_AB_C:
-            return pgmFloat(&e->c1) * (float)a * (float)b;
+            return (int32_t)c1s * a * b / 100;
 
         case F_BK_CA:
-            return ((float)b - pgmFloat(&e->c2)) * pgmFloat(&e->c1) * (float)a;
+        {
+            int16_t c2 = (int16_t)pgm_read_byte(&kC2[raw >> 4]);
+            return (int32_t)c1s * ((int16_t)b - c2) * a / 100;
+        }
 
         case F_ABS_BK_CA:
         {
-            float d = (float)b - pgmFloat(&e->c2);
+            int16_t c2 = (int16_t)pgm_read_byte(&kC2[raw >> 4]);
+            int16_t d = (int16_t)b - c2;
             if (d < 0)
                 d = -d;
-            return d * pgmFloat(&e->c1) * (float)a;
+            return (int32_t)c1s * d * a / 100;
         }
 
         case F_B:
-            return (float)b;
+            return (int32_t)b * 10;
 
         case F_B_A:
-            return (float)b - (float)a;
+            return (int32_t)((int16_t)b - (int16_t)a) * 10;
 
         case F_AK_B:
-            return (float)a * pgmFloat(&e->c1) + (float)b;
-
-        case F_B_AK:
-            return (float)b + (float)a * pgmFloat(&e->c1);
+            return (int32_t)c1s * a / 100 + (int32_t)b * 10; // (a*c1+b)×10
 
         case F_LINEAR:
-            return (float)b * pgmFloat(&e->c1) + (float)a * pgmFloat(&e->c2) + pgmFloat(&e->c3);
+        {
+            // c2 and c3 hardcoded per k, all in integer form.
+            // Formula: v×10 = c1s*b/100 + c2_x10*a/1000 + c3_x10
+            // k=25:  1.421*b + 0.005494*a        → c1s=1421, c2_x100=5494, c3=0
+            // k=40,42: 0.1*b + 25.5*a - 400      → 10*b + 255*a - 4000 (×10)
+            // k=43:  0.1*b + 25.5*a              → 10*b + 255*a
+            // k=53:  1.4222*b + 0.006*a - 182.04 → 14222*b/1000 + 6*a/1000 - 1820 (×10)
+            switch (k)
+            {
+                case 25:
+                    return (int32_t)1421 * b / 100; // c2 term (5494*a/1M) ≈ 0
+                case 40:
+                case 42:
+                    return (int32_t)b * 10 + (int32_t)255 * a - 4000L;
+                case 43:
+                    return (int32_t)b * 10 + (int32_t)255 * a;
+                case 53:
+                    return (int32_t)1422 * b / 100 + 6L * a / 100 - 1820L;
+                default:
+                    return 0;
+            }
+        }
 
         default:
             return 0;
     }
 }
 
+// Out-of-line helpers so LTO can share one function body for each type.
+// Do NOT inline — that defeats the deduplication purpose.
+static void setU8(uint8_t& f, bool& u, uint8_t v)
+{
+    if (f != v)
+    {
+        f = v;
+        u = true;
+    }
+}
+static void setU16(uint16_t& f, bool& u, uint16_t v)
+{
+    if (f != v)
+    {
+        f = v;
+        u = true;
+    }
+}
+static void setU32(uint32_t& f, bool& u, uint32_t v)
+{
+    if (f != v)
+    {
+        f = v;
+        u = true;
+    }
+}
+static void setI8(int8_t& f, bool& u, int8_t v)
+{
+    if (f != v)
+    {
+        f = v;
+        u = true;
+    }
+}
+static void setI16(int16_t& f, bool& u, int16_t v)
+{
+    if (f != v)
+    {
+        f = v;
+        u = true;
+    }
+}
+
 void processKwpMeasurement(uint8_t ecuAddr, uint8_t group, int idx, byte k, byte a, byte b,
                            Model::OBDSignals& signals)
 {
-    float v = 0;
+    int32_t v = 0; // value ×10 fixed-point
     const __FlashStringHelper* units = F("");
 
     // Dispatch formula via table; F_SPECIAL cases fall through to the switch below.
-    if (k < 57 && (FormulaType)pgm_read_byte(&kwp_table[k].type) != F_SPECIAL)
+    if (k < 57 && (FormulaType)(pgm_read_byte(&kwp_table[k].typeAndC2) & 0x0F) != F_SPECIAL)
     {
         v = computeFormula(k, a, b);
     }
     else
     {
-        // Residual switch: 8 cases that don't fit a simple formula family.
+        // Special cases: non-tabulated formulas, all integer arithmetic.
+        // v is ×10 fixed-point throughout.
         switch (k)
         {
-            case 10:
-                v = b;
-                units = b ? F("WARM") : F("COLD"); // unit handled here; skip unit switch below
+            case 10: // WARM/COLD flag
+                v = (int32_t)b * 10;
+                units = b ? F("WARM") : F("COLD");
                 break;
-            case 11:
-                v = 0.0001f * (float)a * ((float)b - 128.0f) + 1.0f;
+            case 11: // lambda: 0.0001*a*(b-128)+1.0
+                // v_x10 = (a*(b-128)/1000 + 1)*10 = a*(b-128)/100 + 10
+                v = (int32_t)a * ((int16_t)b - 128) / 100 + 10;
                 break;
-            case 33:
-                v = 100.0f * (float)b / (float)a;
+            case 20: // %%: (b-128)*a/128
+                v = (int32_t)((int16_t)b - 128) * a * 10 / 128;
                 break;
-            case 36:
-                v = (float)(((uint32_t)a) * 2560UL + ((uint32_t)b) * 10UL);
+            case 23: // %%: a*b/256
+            case 39: // mg/h: same coefficient
+                v = (int32_t)a * b * 10 / 256;
                 break;
-            case 46:
-                v = ((float)a * (float)b - 3200.0f) * 0.0027f;
+            case 31: // °C: a*b/2560
+                v = (int32_t)a * b * 10 / 2560;
                 break;
-            case 50:
-                v = ((float)b - 128.0f) / (0.01f * (float)a);
+            case 33: // %%: 100*b/a
+                v = (a > 0) ? (int32_t)b * 1000 / a : 0;
                 break;
-            case 52:
-                v = (float)b * 0.02f * (float)a - (float)a;
+            case 36: // km: a*2560+b*10
+                v = ((int32_t)a * 2560L + (int32_t)b * 10L) * 10;
+                break;
+            case 41: // Ah: 255*a+b
+            case 48: // raw: same
+                v = ((int32_t)255 * a + b) * 10;
+                break;
+            case 46: // Dk/w: (a*b-3200)*0.0027
+                // v_x10 = (a*b-3200)*27/10000
+                v = ((int32_t)a * b - 3200L) * 27L / 10000L * 10;
+                break;
+            case 50: // mbar: (b-128)/(0.01*a) = (b-128)*100/a
+                v = (a > 0) ? (int32_t)((int16_t)b - 128) * 1000 / a : 0;
+                break;
+            case 51: // mg/h: (b-128)*a/255
+                v = (int32_t)((int16_t)b - 128) * a * 10 / 255;
+                break;
+            case 52: // Nm: b*0.02*a - a = a*(0.02*b-1) → a*(b*20-1000)/1000
+                v = (int32_t)a * ((int32_t)b * 20 - 1000L) / 100;
+                break;
+            case 54: // count: 256*a+b
+            case 56: // raw: same
+                v = ((int32_t)256 * a + b) * 10;
                 break;
             default:
                 break;
@@ -334,28 +425,30 @@ void processKwpMeasurement(uint8_t ecuAddr, uint8_t group, int idx, byte k, byte
         signals.experimental.v[idx] = v;
         signals.experimental.vUpdated = true;
     }
-    char firstChar = pgm_read_byte(reinterpret_cast<const char*>(units));
-    if (signals.experimental.unit[idx][0] != firstChar)
     {
-        uint8_t j = 0;
-        for (; j < obd::Model::ExperimentalGroup::UnitWidth; ++j)
+        char firstChar = pgm_read_byte(reinterpret_cast<const char*>(units));
+        if (signals.experimental.unit[idx][0] != firstChar)
         {
-            char c = pgm_read_byte(
-                reinterpret_cast<const char*>(reinterpret_cast<uintptr_t>(units) + j));
-            if (c == '\0')
-                break;
-            signals.experimental.unit[idx][j] = c;
+            uint8_t j = 0;
+            for (; j < obd::Model::ExperimentalGroup::UnitWidth; ++j)
+            {
+                char c = pgm_read_byte(
+                    reinterpret_cast<const char*>(reinterpret_cast<uintptr_t>(units) + j));
+                if (c == '\0')
+                    break;
+                signals.experimental.unit[idx][j] = c;
+            }
+            if (j <= obd::Model::ExperimentalGroup::UnitWidth)
+            {
+                signals.experimental.unit[idx][j] = '\0';
+            }
+            for (++j; j < obd::Model::ExperimentalGroup::UnitWidth + 1; ++j)
+            {
+                signals.experimental.unit[idx][j] = '\0';
+            }
+            signals.experimental.unitUpdated = true;
         }
-        if (j <= obd::Model::ExperimentalGroup::UnitWidth)
-        {
-            signals.experimental.unit[idx][j] = '\0';
-        }
-        for (++j; j < obd::Model::ExperimentalGroup::UnitWidth + 1; ++j)
-        {
-            signals.experimental.unit[idx][j] = '\0';
-        }
-        signals.experimental.unitUpdated = true;
-    }
+    } // end firstChar block
 
 signal_mapping:
     // Map decoded value into named signal fields
@@ -369,125 +462,60 @@ signal_mapping:
                     switch (idx)
                     {
                         case 0:
-                        {
-                            uint16_t value = (uint16_t)v;
-                            if (signals.instruments.vehicleSpeed != value)
-                            {
-                                signals.instruments.vehicleSpeed = value;
-                                signals.instruments.vehicleSpeedUpdated = true;
-                            }
+                            setU16(signals.instruments.vehicleSpeed,
+                                   signals.instruments.vehicleSpeedUpdated, (uint16_t)(v / 10));
                             break;
-                        }
                         case 1:
-                        {
-                            uint16_t value = (uint16_t)v;
-                            if (signals.instruments.engineRpm != value)
-                            {
-                                signals.instruments.engineRpm = value;
-                                signals.instruments.engineRpmUpdated = true;
-                            }
+                            setU16(signals.instruments.engineRpm,
+                                   signals.instruments.engineRpmUpdated, (uint16_t)(v / 10));
                             break;
-                        }
                         case 2:
-                        {
-                            uint16_t value = (uint16_t)v;
-                            if (signals.instruments.oilPressureMin != value)
-                            {
-                                signals.instruments.oilPressureMin = value;
-                                signals.instruments.oilPressureMinUpdated = true;
-                            }
+                            setU16(signals.instruments.oilPressureMin,
+                                   signals.instruments.oilPressureMinUpdated, (uint16_t)(v / 10));
                             break;
-                        }
                         case 3:
-                        {
-                            uint32_t value = (uint32_t)v;
-                            if (signals.instruments.timeEcu != value)
-                            {
-                                signals.instruments.timeEcu = value;
-                                signals.instruments.timeEcuUpdated = true;
-                            }
+                            setU32(signals.instruments.timeEcu, signals.instruments.timeEcuUpdated,
+                                   (uint32_t)(v / 10));
                             break;
-                        }
                     }
                     break;
                 case 2:
                     switch (idx)
                     {
                         case 0:
-                        {
-                            uint32_t value = (uint32_t)v;
-                            if (signals.instruments.odometer != value)
-                            {
-                                signals.instruments.odometer = value;
-                                signals.instruments.odometerUpdated = true;
-                            }
+                            setU32(signals.instruments.odometer,
+                                   signals.instruments.odometerUpdated, (uint32_t)(v / 10));
                             break;
-                        }
                         case 1:
-                        {
-                            uint8_t value = (uint8_t)v;
-                            if (signals.instruments.fuelLevel != value)
-                            {
-                                signals.instruments.fuelLevel = value;
-                                signals.instruments.fuelLevelUpdated = true;
-                            }
+                            setU8(signals.instruments.fuelLevel,
+                                  signals.instruments.fuelLevelUpdated, (uint8_t)(v / 10));
                             break;
-                        }
                         case 2:
-                        {
-                            uint16_t value = (uint16_t)v;
-                            if (signals.instruments.fuelSensorResistance != value)
-                            {
-                                signals.instruments.fuelSensorResistance = value;
-                                signals.instruments.fuelSensorResistanceUpdated = true;
-                            }
+                            setU16(signals.instruments.fuelSensorResistance,
+                                   signals.instruments.fuelSensorResistanceUpdated,
+                                   (uint16_t)(v / 10));
                             break;
-                        }
                         case 3:
-                        {
-                            uint8_t value = (uint8_t)v;
-                            if (signals.instruments.ambientTemp != value)
-                            {
-                                signals.instruments.ambientTemp = value;
-                                signals.instruments.ambientTempUpdated = true;
-                            }
+                            setU8(signals.instruments.ambientTemp,
+                                  signals.instruments.ambientTempUpdated, (uint8_t)(v / 10));
                             break;
-                        }
                     }
                     break;
                 case 3:
                     switch (idx)
                     {
                         case 0:
-                        {
-                            uint8_t value = (uint8_t)v;
-                            if (signals.instruments.coolantTemp != value)
-                            {
-                                signals.instruments.coolantTemp = value;
-                                signals.instruments.coolantTempUpdated = true;
-                            }
+                            setU8(signals.instruments.coolantTemp,
+                                  signals.instruments.coolantTempUpdated, (uint8_t)(v / 10));
                             break;
-                        }
                         case 1:
-                        {
-                            uint8_t value = (uint8_t)v;
-                            if (signals.instruments.oilLevelOk != value)
-                            {
-                                signals.instruments.oilLevelOk = value;
-                                signals.instruments.oilLevelOkUpdated = true;
-                            }
+                            setU8(signals.instruments.oilLevelOk,
+                                  signals.instruments.oilLevelOkUpdated, (uint8_t)(v / 10));
                             break;
-                        }
                         case 2:
-                        {
-                            uint8_t value = (uint8_t)v;
-                            if (signals.instruments.oilTemp != value)
-                            {
-                                signals.instruments.oilTemp = value;
-                                signals.instruments.oilTempUpdated = true;
-                            }
+                            setU8(signals.instruments.oilTemp, signals.instruments.oilTempUpdated,
+                                  (uint8_t)(v / 10));
                             break;
-                        }
                         default:
                             break;
                     }
@@ -505,35 +533,17 @@ signal_mapping:
                     switch (idx)
                     {
                         case 0:
-                        {
-                            uint16_t value = (uint16_t)v;
-                            if (signals.instruments.engineRpm != value)
-                            {
-                                signals.instruments.engineRpm = value;
-                                signals.instruments.engineRpmUpdated = true;
-                            }
+                            setU16(signals.instruments.engineRpm,
+                                   signals.instruments.engineRpmUpdated, (uint16_t)(v / 10));
                             break;
-                        }
                         case 1:
-                        {
-                            uint8_t value = (uint8_t)v;
-                            if (signals.engine.tempUnknown1 != value)
-                            {
-                                signals.engine.tempUnknown1 = value;
-                                signals.engine.tempUnknown1Updated = true;
-                            }
+                            setU8(signals.engine.tempUnknown1, signals.engine.tempUnknown1Updated,
+                                  (uint8_t)(v / 10));
                             break;
-                        }
                         case 2:
-                        {
-                            int8_t value = (int8_t)v;
-                            if (signals.engine.lambda != value)
-                            {
-                                signals.engine.lambda = value;
-                                signals.engine.lambdaUpdated = true;
-                            }
+                            setI8(signals.engine.lambda, signals.engine.lambdaUpdated,
+                                  (int8_t)(v / 10));
                             break;
-                        }
                         default:
                             break;
                     }
@@ -542,95 +552,47 @@ signal_mapping:
                     switch (idx)
                     {
                         case 1:
-                        {
-                            uint16_t value = (uint16_t)v;
-                            if (signals.engine.pressure != value)
-                            {
-                                signals.engine.pressure = value;
-                                signals.engine.pressureUpdated = true;
-                            }
+                            setU16(signals.engine.pressure, signals.engine.pressureUpdated,
+                                   (uint16_t)(v / 10));
                             break;
-                        }
                         case 2:
-                        {
-                            float value = v;
-                            if (signals.engine.tbAngle != value)
-                            {
-                                signals.engine.tbAngle = value;
-                                signals.engine.tbAngleUpdated = true;
-                            }
-                            break;
-                        }
+                            setI16(signals.engine.tbAngle, signals.engine.tbAngleUpdated,
+                                   (int16_t)v);
+                            break; // ×10
                         case 3:
-                        {
-                            float value = v;
-                            if (signals.engine.steeringAngle != value)
-                            {
-                                signals.engine.steeringAngle = value;
-                                signals.engine.steeringAngleUpdated = true;
-                            }
-                            break;
-                        }
+                            setI16(signals.engine.steeringAngle,
+                                   signals.engine.steeringAngleUpdated, (int16_t)v);
+                            break; // ×10
                     }
                     break;
                 case 4:
                     switch (idx)
                     {
                         case 1:
-                        {
-                            float value = v;
-                            if (signals.engine.voltage != value)
-                            {
-                                signals.engine.voltage = value;
-                                signals.engine.voltageUpdated = true;
-                            }
-                            break;
-                        }
+                            setU16(signals.engine.voltage, signals.engine.voltageUpdated,
+                                   (uint16_t)v);
+                            break; // ×10
                         case 2:
-                        {
-                            uint8_t value = (uint8_t)v;
-                            if (signals.engine.tempUnknown2 != value)
-                            {
-                                signals.engine.tempUnknown2 = value;
-                                signals.engine.tempUnknown2Updated = true;
-                            }
+                            setU8(signals.engine.tempUnknown2, signals.engine.tempUnknown2Updated,
+                                  (uint8_t)(v / 10));
                             break;
-                        }
                         case 3:
-                        {
-                            uint8_t value = (uint8_t)v;
-                            if (signals.engine.tempUnknown3 != value)
-                            {
-                                signals.engine.tempUnknown3 = value;
-                                signals.engine.tempUnknown3Updated = true;
-                            }
+                            setU8(signals.engine.tempUnknown3, signals.engine.tempUnknown3Updated,
+                                  (uint8_t)(v / 10));
                             break;
-                        }
                     }
                     break;
                 case 6:
                     switch (idx)
                     {
                         case 1:
-                        {
-                            uint16_t value = (uint16_t)v;
-                            if (signals.engine.engineLoad != value)
-                            {
-                                signals.engine.engineLoad = value;
-                                signals.engine.engineLoadUpdated = true;
-                            }
+                            setU16(signals.engine.engineLoad, signals.engine.engineLoadUpdated,
+                                   (uint16_t)(v / 10));
                             break;
-                        }
                         case 3:
-                        {
-                            int8_t value = (int8_t)v;
-                            if (signals.engine.lambda2 != value)
-                            {
-                                signals.engine.lambda2 = value;
-                                signals.engine.lambda2Updated = true;
-                            }
+                            setI8(signals.engine.lambda2, signals.engine.lambda2Updated,
+                                  (int8_t)(v / 10));
                             break;
-                        }
                     }
                     break;
                 default:

--- a/src/obd/Model/OBDSignals.cpp
+++ b/src/obd/Model/OBDSignals.cpp
@@ -11,7 +11,7 @@ void ExperimentalGroup::reset()
     for (uint8_t i = 0; i < 4; ++i)
     {
         k[i] = 0;
-        v[i] = 123.4f;
+        v[i] = 1234; // 123.4 ×10
         // Reset unit text to "N/A"
         unit[i][0] = 'N';
         unit[i][1] = '/';
@@ -54,26 +54,18 @@ void OBDSignals::compute(uint32_t nowMs, uint32_t connectTimeStart)
         abs((int)instruments.fuelLevelStart - (int)instruments.fuelLevel);
     computed.fuelBurnedSinceStartUpdated = true;
 
-    if (computed.elapsedKmSinceStart > 0)
-    {
-        computed.fuelPer100km =
-            (100.0f / computed.elapsedKmSinceStart) * computed.fuelBurnedSinceStart;
-    }
-    else
-    {
-        computed.fuelPer100km = 0.0f;
-    }
+    // fuelPer100km ×10: burned*1000/km (e.g. 5L/60km → 83 = 8.3 L/100km)
+    computed.fuelPer100km = (computed.elapsedKmSinceStart > 0)
+                                ? (uint16_t)((uint32_t)computed.fuelBurnedSinceStart * 1000u /
+                                             computed.elapsedKmSinceStart)
+                                : 0u;
     computed.fuelPer100kmUpdated = true;
 
-    if (computed.elapsedSecondsSinceStart > 0)
-    {
-        computed.fuelPerHour =
-            (3600.0f / computed.elapsedSecondsSinceStart) * computed.fuelBurnedSinceStart;
-    }
-    else
-    {
-        computed.fuelPerHour = 0.0f;
-    }
+    // fuelPerHour ×10: burned*36000/sec (e.g. 5L/1800s → 100 = 10.0 L/h)
+    computed.fuelPerHour = (computed.elapsedSecondsSinceStart > 0)
+                               ? (uint16_t)((uint32_t)computed.fuelBurnedSinceStart * 36000u /
+                                            computed.elapsedSecondsSinceStart)
+                               : 0u;
     computed.fuelPerHourUpdated = true;
 }
 

--- a/src/obd/Model/OBDSignals.h
+++ b/src/obd/Model/OBDSignals.h
@@ -11,7 +11,7 @@ namespace Model
 struct ExperimentalGroup
 {
     uint8_t k[4] = {0, 0, 0, 0};
-    float v[4] = {123.4f, 123.4f, 123.4f, 123.4f};
+    int32_t v[4] = {1234, 1234, 1234, 1234}; // ×10 fixed-point (e.g. 1234 = 123.4)
     // Fixed-size unit strings to avoid dynamic String allocations; initialized to "N/A".
     static constexpr uint8_t UnitWidth = 8; // enough for typical short unit labels
     char unit[4][UnitWidth + 1] = {
@@ -90,13 +90,13 @@ struct EngineSignals
     uint16_t pressure = 0;
     bool pressureUpdated = false;
 
-    float tbAngle = 0.0f;
+    int16_t tbAngle = 0; // ×10 fixed-point (e.g. 456 = 45.6°)
     bool tbAngleUpdated = false;
 
-    float steeringAngle = 0.0f;
+    int16_t steeringAngle = 0; // ×10 fixed-point
     bool steeringAngleUpdated = false;
 
-    float voltage = 0.0f;
+    uint16_t voltage = 0; // ×10 fixed-point (e.g. 123 = 12.3 V)
     bool voltageUpdated = false;
 
     uint8_t tempUnknown2 = 0;
@@ -123,10 +123,10 @@ struct ComputedStats
     uint8_t fuelBurnedSinceStart = 0;
     bool fuelBurnedSinceStartUpdated = false;
 
-    float fuelPer100km = 0.0f;
+    uint16_t fuelPer100km = 0; // ×10 fixed-point (e.g. 83 = 8.3 L/100km)
     bool fuelPer100kmUpdated = false;
 
-    float fuelPerHour = 0.0f;
+    uint16_t fuelPerHour = 0; // ×10 fixed-point (e.g. 45 = 4.5 L/h)
     bool fuelPerHourUpdated = false;
 };
 

--- a/src/obd/OBDDisplay.cpp
+++ b/src/obd/OBDDisplay.cpp
@@ -35,9 +35,8 @@ static constexpr uint8_t BTN_MASK_DOWN = 0x08;
 static constexpr uint8_t BTN_MASK_MID = 0x10;
 
 OBDDisplay::OBDDisplay(uint8_t rxPin, uint8_t txPin, ::Display& display)
-    : obdSerial_(rxPin, txPin, false), display_(display), kwp_(obdSerial_, txPin), signals_(),
-      dtcStore_(), menuState_(),
-      buttons_(BTN_PIN_UP, BTN_PIN_DOWN, BTN_PIN_LEFT, BTN_PIN_RIGHT, BTN_PIN_MID),
+    : obdSerial_(rxPin, txPin), display_(display), kwp_(obdSerial_, txPin), signals_(), dtcStore_(),
+      menuState_(), buttons_(BTN_PIN_UP, BTN_PIN_DOWN, BTN_PIN_LEFT, BTN_PIN_RIGHT, BTN_PIN_MID),
       simulationModeActive_(false), autoSetup_(false), baudRate_(0), addrSelected_(0x00),
       kwpMode_(Mode::ReadSensors), kwpModeLast_(Mode::ReadSensors), kwpGroup_(1), connected_(false),
       connectTimeStart_(0), displayFrameTimestamp_(0), buttonTimeoutUntil_(0)

--- a/src/obd/OBDDisplay.cpp
+++ b/src/obd/OBDDisplay.cpp
@@ -511,41 +511,22 @@ void OBDDisplay::handleInput_()
         switch (menuState_.currentMenu())
         {
             case MenuId::Cockpit:
-                if (btns & BTN_MASK_UP)
-                {
-                    menuState_.nextCockpitScreen();
-                    any = true;
-                }
-                else if (btns & BTN_MASK_DOWN)
-                {
-                    menuState_.prevCockpitScreen();
-                    any = true;
-                }
-                break;
             case MenuId::Experimental:
-                if (btns & BTN_MASK_UP)
-                {
-                    menuState_.nextExperimentalScreen();
-                    any = true;
-                }
-                else if (btns & BTN_MASK_DOWN)
-                {
-                    menuState_.prevExperimentalScreen();
-                    any = true;
-                }
-                break;
             case MenuId::Debug:
+            {
+                MenuId mid = menuState_.currentMenu();
                 if (btns & BTN_MASK_UP)
                 {
-                    menuState_.nextDebugScreen();
+                    menuState_.nextScreen(mid);
                     any = true;
                 }
                 else if (btns & BTN_MASK_DOWN)
                 {
-                    menuState_.prevDebugScreen();
+                    menuState_.prevScreen(mid);
                     any = true;
                 }
                 break;
+            }
             case MenuId::Dtc:
                 if (dtcShowActive_)
                 {
@@ -677,11 +658,11 @@ void OBDDisplay::handleInput_()
     // Keep groupCurrent and kwpGroup_ in sync with the experimental screen index.
     if (menuState_.currentMenu() == Display::MenuId::Experimental)
     {
-        if (menuState_.experimentalScreen() == 0)
+        if (menuState_.screen(Display::MenuId::Experimental) == 0)
         {
-            menuState_.setExperimentalScreen(1);
+            menuState_.setScreen(Display::MenuId::Experimental, 1);
         }
-        signals_.experimental.groupCurrent = menuState_.experimentalScreen();
+        signals_.experimental.groupCurrent = menuState_.screen(Display::MenuId::Experimental);
         kwpGroup_ = signals_.experimental.groupCurrent; // ReadGroup mode uses this
         signals_.experimental.kUpdated = true;
     }

--- a/src/scheduler/TaskConfig.h
+++ b/src/scheduler/TaskConfig.h
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
-// Cooperative task scheduler intervals (milliseconds).
-// KWP serial is timing-critical and runs every loop iteration (0 = no delay).
-// Display and compute tasks use longer intervals to avoid starving the ECU comms.
-#define _TASK_SLEEP_ON_IDLE_RUN
-#include <TaskScheduler.h>
-
-static constexpr uint32_t INTERVAL_KWP_MS = 0;         // every loop — ECU must not time out
-static constexpr uint32_t INTERVAL_INPUT_MS = 20;      // button latch polling interval
-static constexpr uint32_t INTERVAL_COMPUTE_MS = 50;    // fuel calc, derived stats
-static constexpr uint32_t INTERVAL_DISPLAY_MS = 177;   // ~5.6 FPS
-static constexpr uint32_t INTERVAL_KEEPALIVE_MS = 800; // KWP ACK when idle
+// Cooperative task intervals (milliseconds).
+// KWP is timing-critical; interval=0 means run every loop iteration.
+static constexpr uint16_t INTERVAL_KWP_MS = 0;
+static constexpr uint16_t INTERVAL_INPUT_MS = 20;
+static constexpr uint16_t INTERVAL_COMPUTE_MS = 50;
+static constexpr uint16_t INTERVAL_DISPLAY_MS = 177;
+static constexpr uint32_t INTERVAL_KEEPALIVE_MS = 800;

--- a/src/serial/NewSoftwareSerial.cpp
+++ b/src/serial/NewSoftwareSerial.cpp
@@ -1,51 +1,12 @@
-/*
-NewSoftwareSerial.cpp (formerly SoftSerial.cpp) -
-Multi-instance software serial library for Arduino/Wiring
--- Interrupt-driven receive and other improvements by ladyada
-   (http://ladyada.net)
--- Tuning, circular buffer, derivation from class Print/Stream,
-   multi-instance support, porting to 8MHz processors,
-   various optimizations, PROGMEM delay tables, inverse logic and
-   direct port writing by Mikal Hart (http://www.arduiniana.org)
--- Pin change interrupt macros by Paul Stoffregen (http://www.pjrc.com)
--- 20MHz processor support by Garrett Mace (http://www.macetech.com)
--- ATmega1280/2560 support by Brett Hagman (http://www.roguerobotics.com/)
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-
-The latest version of this library can always be found at
-http://arduiniana.org.
-*/
-
-// When set, _DEBUG co-opts pins 11 and 13 for debugging with an
-// oscilloscope or logic analyzer.  Beware: it also slightly modifies
-// the bit times, so don't rely on it too much at high baud rates
-#define _DEBUG 0
-#define _DEBUG_PIN1 11
-#define _DEBUG_PIN2 13
-//
-// Includes
-//
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Stripped NewSoftwareSerial: 16 MHz only, 5 KWP baud rates,
+// no Stream/Print, no inverse logic, single instance.
 #include <avr/interrupt.h>
 #include <avr/pgmspace.h>
 #include <Arduino.h>
 #include "NewSoftwareSerial.h"
-//
-// Lookup table
-//
-typedef struct _DELAY_TABLE
+
+typedef struct
 {
     long baud;
     unsigned short rx_delay_centering;
@@ -54,356 +15,24 @@ typedef struct _DELAY_TABLE
     unsigned short tx_delay;
 } DELAY_TABLE;
 
-#if F_CPU == 16000000
-
+// 16 MHz — only the 5 baud rates needed for KWP-1281 VAG ECUs.
 static const DELAY_TABLE PROGMEM table[] = {
-    //  baud    rxcenter   rxintra    rxstop    tx
-    {
-        115200,
-        1,
-        17,
-        17,
-        12,
-    },
-    {
-        57600,
-        10,
-        37,
-        37,
-        33,
-    },
-    {
-        38400,
-        25,
-        57,
-        57,
-        54,
-    },
-    {
-        31250,
-        31,
-        70,
-        70,
-        68,
-    },
-    {
-        28800,
-        34,
-        77,
-        77,
-        74,
-    },
-    {
-        19200,
-        54,
-        117,
-        117,
-        114,
-    },
-    {
-        14400,
-        74,
-        156,
-        156,
-        153,
-    },
-    {
-        10400,
-        106,
-        218,
-        218,
-        215,
-    },
-    {
-        9600,
-        114,
-        236,
-        236,
-        233,
-    },
-    {
-        4800,
-        233,
-        474,
-        474,
-        471,
-    },
-    {
-        2400,
-        471,
-        950,
-        950,
-        947,
-    },
-    {
-        1200,
-        947,
-        1902,
-        1902,
-        1899,
-    },
-    {
-        600,
-        1902,
-        3804,
-        3804,
-        3800,
-    },
-    {
-        300,
-        3804,
-        7617,
-        7617,
-        7614,
-    },
+    // baud   rxcenter  rxintra  rxstop   tx
+    {10400, 106, 218, 218, 215}, {9600, 114, 236, 236, 233},    {4800, 233, 474, 474, 471},
+    {2400, 471, 950, 950, 947},  {1200, 947, 1902, 1902, 1899},
 };
 
 const int XMIT_START_ADJUSTMENT = 5;
 
-#elif F_CPU == 8000000
-
-// cppcheck-suppress unknownMacro
-static const DELAY_TABLE table[] PROGMEM = {
-    //  baud    rxcenter    rxintra    rxstop  tx
-    {
-        115200,
-        1,
-        5,
-        5,
-        3,
-    },
-    {
-        57600,
-        1,
-        15,
-        15,
-        13,
-    },
-    {
-        38400,
-        2,
-        25,
-        26,
-        23,
-    },
-    {
-        31250,
-        7,
-        32,
-        33,
-        29,
-    },
-    {
-        28800,
-        11,
-        35,
-        35,
-        32,
-    },
-    {
-        19200,
-        20,
-        55,
-        55,
-        52,
-    },
-    {
-        14400,
-        30,
-        75,
-        75,
-        72,
-    },
-    {
-        9600,
-        50,
-        114,
-        114,
-        112,
-    },
-    {
-        4800,
-        110,
-        233,
-        233,
-        230,
-    },
-    {
-        2400,
-        229,
-        472,
-        472,
-        469,
-    },
-    {
-        1200,
-        467,
-        948,
-        948,
-        945,
-    },
-    {
-        600,
-        948,
-        1895,
-        1895,
-        1890,
-    },
-    {
-        300,
-        1895,
-        3805,
-        3805,
-        3802,
-    },
-};
-
-const int XMIT_START_ADJUSTMENT = 4;
-
-#elif F_CPU == 20000000
-
-// 20MHz support courtesy of the good people at macegr.com.
-// Thanks, Garrett!
-
-static const DELAY_TABLE PROGMEM table[] = {
-    //  baud    rxcenter    rxintra    rxstop  tx
-    {
-        115200,
-        3,
-        21,
-        21,
-        18,
-    },
-    {
-        57600,
-        20,
-        43,
-        43,
-        41,
-    },
-    {
-        38400,
-        37,
-        73,
-        73,
-        70,
-    },
-    {
-        31250,
-        45,
-        89,
-        89,
-        88,
-    },
-    {
-        28800,
-        46,
-        98,
-        98,
-        95,
-    },
-    {
-        19200,
-        71,
-        148,
-        148,
-        145,
-    },
-    {
-        14400,
-        96,
-        197,
-        197,
-        194,
-    },
-    {
-        9600,
-        146,
-        297,
-        297,
-        294,
-    },
-    {
-        4800,
-        296,
-        595,
-        595,
-        592,
-    },
-    {
-        2400,
-        592,
-        1189,
-        1189,
-        1186,
-    },
-    {
-        1200,
-        1187,
-        2379,
-        2379,
-        2376,
-    },
-    {
-        600,
-        2379,
-        4759,
-        4759,
-        4755,
-    },
-    {
-        300,
-        4759,
-        9523,
-        9523,
-        9520,
-    },
-};
-
-const int XMIT_START_ADJUSTMENT = 6;
-
-#else
-
-#error This version of SoftwareSerial supports only 20, 16 and 8MHz processors
-
-#endif
-
-//
-// Statics
-//
-NewSoftwareSerial* NewSoftwareSerial::active_object = 0;
+// Static member definitions
 char NewSoftwareSerial::_receive_buffer[_SS_MAX_RX_BUFF];
 volatile uint8_t NewSoftwareSerial::_receive_buffer_tail = 0;
 volatile uint8_t NewSoftwareSerial::_receive_buffer_head = 0;
+NewSoftwareSerial* NewSoftwareSerial::_instance = nullptr;
 
-//
-// Debugging
-//
-// This function generates a brief pulse
-// for debugging or measuring on an oscilloscope.
-inline void DebugPulse(uint8_t pin, uint8_t count)
-{
-#if _DEBUG
-    volatile uint8_t* pport = portOutputRegister(digitalPinToPort(pin));
-
-    uint8_t val = *pport;
-    while (count--)
-    {
-        *pport = val | digitalPinToBitMask(pin);
-        *pport = val;
-    }
-#endif
-}
-
-//
-// Private methods
-//
-
-/* static */
 inline void NewSoftwareSerial::tunedDelay(uint16_t delay)
 {
     uint8_t tmp = 0;
-
     asm volatile("sbiw    %0, 0x01 \n\t"
                  "ldi %1, 0xFF \n\t"
                  "cpi %A0, 0xFF \n\t"
@@ -413,100 +42,32 @@ inline void NewSoftwareSerial::tunedDelay(uint16_t delay)
                  : "0"(delay));
 }
 
-// This function sets the current object as the "listening"
-// one and returns true if it replaces another
-bool NewSoftwareSerial::listen()
-{
-    if (active_object != this)
-    {
-        _buffer_overflow = false;
-        uint8_t oldSREG = SREG;
-        cli();
-        _receive_buffer_head = _receive_buffer_tail = 0;
-        active_object = this;
-        SREG = oldSREG;
-        return true;
-    }
-
-    return false;
-}
-
-//
-// The receive routine called by the interrupt handler
-//
 void NewSoftwareSerial::recv()
 {
-#if GCC_VERSION < 40302
-    // Work-around for avr-gcc 4.3.0 OSX version bug
-    // Preserve the registers that the compiler misses
-    // (courtesy of Arduino forum user *etracer*)
-    asm volatile("push r18 \n\t"
-                 "push r19 \n\t"
-                 "push r20 \n\t"
-                 "push r21 \n\t"
-                 "push r22 \n\t"
-                 "push r23 \n\t"
-                 "push r26 \n\t"
-                 "push r27 \n\t" ::);
-#endif
-
-    uint8_t d = 0;
-
-    // If RX line is high, then we don't see any start bit
-    // so interrupt is probably not for us
-    if (_inverse_logic ? rx_pin_read() : !rx_pin_read())
+    // Only sample if start bit is present (RX line low)
+    if (!rx_pin_read())
     {
-        // Wait approximately 1/2 of a bit width to "center" the sample
+        uint8_t d = 0;
         tunedDelay(_rx_delay_centering);
-        DebugPulse(_DEBUG_PIN2, 1);
 
-        // Read each of the 8 bits
         for (uint8_t i = 0x1; i; i <<= 1)
         {
             tunedDelay(_rx_delay_intrabit);
-            DebugPulse(_DEBUG_PIN2, 1);
             uint8_t noti = ~i;
             if (rx_pin_read())
                 d |= i;
-            else // else clause added to ensure function timing is ~balanced
+            else
                 d &= noti;
         }
 
-        // skip the stop bit
         tunedDelay(_rx_delay_stopbit);
-        DebugPulse(_DEBUG_PIN2, 1);
 
-        if (_inverse_logic)
-            d = ~d;
-
-        // if buffer full, set the overflow flag and return
         if ((_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF != _receive_buffer_head)
         {
-            // save new data in buffer: tail points to where byte goes
-            _receive_buffer[_receive_buffer_tail] = d; // save new byte
+            _receive_buffer[_receive_buffer_tail] = d;
             _receive_buffer_tail = (_receive_buffer_tail + 1) % _SS_MAX_RX_BUFF;
         }
-        else
-        {
-#if _DEBUG // for scope: pulse pin as overflow indictator
-            DebugPulse(_DEBUG_PIN1, 1);
-#endif
-            _buffer_overflow = true;
-        }
     }
-
-#if GCC_VERSION < 40302
-    // Work-around for avr-gcc 4.3.0 OSX version bug
-    // Restore the registers that the compiler misses
-    asm volatile("pop r27 \n\t"
-                 "pop r26 \n\t"
-                 "pop r23 \n\t"
-                 "pop r22 \n\t"
-                 "pop r21 \n\t"
-                 "pop r20 \n\t"
-                 "pop r19 \n\t"
-                 "pop r18 \n\t" ::);
-#endif
 }
 
 void NewSoftwareSerial::tx_pin_write(uint8_t pin_state)
@@ -522,17 +83,10 @@ uint8_t NewSoftwareSerial::rx_pin_read()
     return *_receivePortRegister & _receiveBitMask;
 }
 
-//
-// Interrupt handling
-//
-
-/* static */
 inline void NewSoftwareSerial::handle_interrupt()
 {
-    if (active_object)
-    {
-        active_object->recv();
-    }
+    if (_instance)
+        _instance->recv();
 }
 
 #if defined(PCINT0_vect)
@@ -541,21 +95,18 @@ ISR(PCINT0_vect)
     NewSoftwareSerial::handle_interrupt();
 }
 #endif
-
 #if defined(PCINT1_vect)
 ISR(PCINT1_vect)
 {
     NewSoftwareSerial::handle_interrupt();
 }
 #endif
-
 #if defined(PCINT2_vect)
 ISR(PCINT2_vect)
 {
     NewSoftwareSerial::handle_interrupt();
 }
 #endif
-
 #if defined(PCINT3_vect)
 ISR(PCINT3_vect)
 {
@@ -563,21 +114,15 @@ ISR(PCINT3_vect)
 }
 #endif
 
-//
-// Constructor
-//
-NewSoftwareSerial::NewSoftwareSerial(uint8_t receivePin, uint8_t transmitPin,
-                                     bool inverse_logic /* = false */)
-    : _rx_delay_centering(0), _rx_delay_intrabit(0), _rx_delay_stopbit(0), _tx_delay(0),
-      _buffer_overflow(false), _inverse_logic(inverse_logic)
+NewSoftwareSerial::NewSoftwareSerial(uint8_t receivePin, uint8_t transmitPin)
+    : _receivePin(0), _receiveBitMask(0), _receivePortRegister(nullptr), _transmitBitMask(0),
+      _transmitPortRegister(nullptr), _rx_delay_centering(0), _rx_delay_intrabit(0),
+      _rx_delay_stopbit(0), _tx_delay(0)
 {
     setTX(transmitPin);
     setRX(receivePin);
 }
 
-//
-// Destructor
-//
 NewSoftwareSerial::~NewSoftwareSerial()
 {
     end();
@@ -588,30 +133,23 @@ void NewSoftwareSerial::setTX(uint8_t tx)
     pinMode(tx, OUTPUT);
     digitalWrite(tx, HIGH);
     _transmitBitMask = digitalPinToBitMask(tx);
-    uint8_t port = digitalPinToPort(tx);
-    _transmitPortRegister = portOutputRegister(port);
+    _transmitPortRegister = portOutputRegister(digitalPinToPort(tx));
 }
 
 void NewSoftwareSerial::setRX(uint8_t rx)
 {
     pinMode(rx, INPUT);
-    if (!_inverse_logic)
-        digitalWrite(rx, HIGH); // pullup for normal logic!
+    digitalWrite(rx, HIGH); // enable pullup
     _receivePin = rx;
     _receiveBitMask = digitalPinToBitMask(rx);
-    uint8_t port = digitalPinToPort(rx);
-    _receivePortRegister = portInputRegister(port);
+    _receivePortRegister = portInputRegister(digitalPinToPort(rx));
 }
-
-//
-// Public methods
-//
 
 void NewSoftwareSerial::begin(long speed)
 {
     _rx_delay_centering = _rx_delay_intrabit = _rx_delay_stopbit = _tx_delay = 0;
 
-    for (unsigned i = 0; i < sizeof(table) / sizeof(table[0]); ++i)
+    for (uint8_t i = 0; i < sizeof(table) / sizeof(table[0]); ++i)
     {
         long baud = pgm_read_dword(&table[i].baud);
         if (baud == speed)
@@ -623,9 +161,7 @@ void NewSoftwareSerial::begin(long speed)
             break;
         }
     }
-    // Serial.println(_rx_delay_stopbit);
 
-    // Set up RX interrupts, but only if we have a valid RX baud rate
     if (_rx_delay_stopbit)
     {
         if (digitalPinToPCICR(_receivePin))
@@ -633,15 +169,11 @@ void NewSoftwareSerial::begin(long speed)
             *digitalPinToPCICR(_receivePin) |= _BV(digitalPinToPCICRbit(_receivePin));
             *digitalPinToPCMSK(_receivePin) |= _BV(digitalPinToPCMSKbit(_receivePin));
         }
-        tunedDelay(_tx_delay); // if we were low this establishes the end
+        tunedDelay(_tx_delay);
     }
 
-#if _DEBUG
-    pinMode(_DEBUG_PIN1, OUTPUT);
-    pinMode(_DEBUG_PIN2, OUTPUT);
-#endif
-
-    listen();
+    _receive_buffer_head = _receive_buffer_tail = 0;
+    _instance = this;
 }
 
 void NewSoftwareSerial::end()
@@ -650,101 +182,45 @@ void NewSoftwareSerial::end()
         *digitalPinToPCMSK(_receivePin) &= ~_BV(digitalPinToPCMSKbit(_receivePin));
 }
 
-// Read data from buffer
+// cppcheck-suppress functionStatic
 int NewSoftwareSerial::read()
 {
-    if (!isListening())
-        return -1;
-
-    // Empty buffer?
     if (_receive_buffer_head == _receive_buffer_tail)
         return -1;
-
-    // Read from "head"
-    uint8_t d = _receive_buffer[_receive_buffer_head]; // grab next byte
+    uint8_t d = _receive_buffer[_receive_buffer_head];
     _receive_buffer_head = (_receive_buffer_head + 1) % _SS_MAX_RX_BUFF;
     return d;
 }
 
+// cppcheck-suppress functionStatic
 int NewSoftwareSerial::available()
 {
-    if (!isListening())
-        return 0;
-
     return (_receive_buffer_tail + _SS_MAX_RX_BUFF - _receive_buffer_head) % _SS_MAX_RX_BUFF;
 }
 
 size_t NewSoftwareSerial::write(uint8_t b)
 {
     if (_tx_delay == 0)
-    {
-        setWriteError();
         return 0;
-    }
-
-    uint8_t oldSREG = SREG;
-    cli(); // turn off interrupts for a clean txmit
-
-    // Write the start bit
-    tx_pin_write(_inverse_logic ? HIGH : LOW);
-    tunedDelay(_tx_delay + XMIT_START_ADJUSTMENT);
-
-    // Write each of the 8 bits
-    if (_inverse_logic)
-    {
-        for (byte mask = 0x01; mask; mask <<= 1)
-        {
-            if (b & mask)          // choose bit
-                tx_pin_write(LOW); // send 1
-            else
-                tx_pin_write(HIGH); // send 0
-
-            tunedDelay(_tx_delay);
-        }
-
-        tx_pin_write(LOW); // restore pin to natural state
-    }
-    else
-    {
-        for (byte mask = 0x01; mask; mask <<= 1)
-        {
-            if (b & mask)           // choose bit
-                tx_pin_write(HIGH); // send 1
-            else
-                tx_pin_write(LOW); // send 0
-
-            tunedDelay(_tx_delay);
-        }
-
-        tx_pin_write(HIGH); // restore pin to natural state
-    }
-
-    SREG = oldSREG; // turn interrupts back on
-    tunedDelay(_tx_delay);
-
-    return 1;
-}
-
-void NewSoftwareSerial::flush()
-{
-    if (!isListening())
-        return;
 
     uint8_t oldSREG = SREG;
     cli();
-    _receive_buffer_head = _receive_buffer_tail = 0;
+
+    tx_pin_write(LOW); // start bit
+    tunedDelay(_tx_delay + XMIT_START_ADJUSTMENT);
+
+    for (byte mask = 0x01; mask; mask <<= 1)
+    {
+        if (b & mask)
+            tx_pin_write(HIGH);
+        else
+            tx_pin_write(LOW);
+        tunedDelay(_tx_delay);
+    }
+
+    tx_pin_write(HIGH); // stop bit / idle
     SREG = oldSREG;
-}
+    tunedDelay(_tx_delay);
 
-int NewSoftwareSerial::peek()
-{
-    if (!isListening())
-        return -1;
-
-    // Empty buffer?
-    if (_receive_buffer_head == _receive_buffer_tail)
-        return -1;
-
-    // Read from "head"
-    return _receive_buffer[_receive_buffer_head];
+    return 1;
 }

--- a/src/serial/NewSoftwareSerial.h
+++ b/src/serial/NewSoftwareSerial.h
@@ -1,53 +1,18 @@
-/*
-NewSoftwareSerial.h (formerly SoftSerial.h) -
-Multi-instance software serial library for Arduino/Wiring
--- Interrupt-driven receive and other improvements by ladyada
-   (http://ladyada.net)
--- Tuning, circular buffer, derivation from class Print/Stream,
-   multi-instance support, porting to 8MHz processors,
-   various optimizations, PROGMEM delay tables, inverse logic and
-   direct port writing by Mikal Hart (http://www.arduiniana.org)
--- Pin change interrupt macros by Paul Stoffregen (http://www.pjrc.com)
--- 20MHz processor support by Garrett Mace (http://www.macetech.com)
--- ATmega1280/2560 support by Brett Hagman (http://www.roguerobotics.com/)
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-
-The latest version of this library can always be found at
-http://arduiniana.org.
-*/
-
-#ifndef NewSoftwareSerial_h
-#define NewSoftwareSerial_h
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Stripped-down software serial for KWP-1281 K-Line communication.
+// Keeps only the 5 baud rates used by VAG ECUs (1200–10400), removes
+// Stream/Print inheritance (~400 bytes), inverse logic, multi-instance
+// support, and peek/flush.  API compatible with KWP1281Session usage:
+// begin(), write(), read(), available().
+#pragma once
 
 #include <inttypes.h>
-#include <Stream.h>
 
-/******************************************************************************
- * Definitions
- ******************************************************************************/
+#define _SS_MAX_RX_BUFF 64
 
-#define _SS_MAX_RX_BUFF 64 // RX buffer size
-#ifndef GCC_VERSION
-#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#endif
-
-class NewSoftwareSerial : public Stream
+class NewSoftwareSerial
 {
   private:
-    // per object data
     uint8_t _receivePin;
     uint8_t _receiveBitMask;
     volatile uint8_t* _receivePortRegister;
@@ -59,59 +24,37 @@ class NewSoftwareSerial : public Stream
     uint16_t _rx_delay_stopbit;
     uint16_t _tx_delay;
 
-    uint16_t _buffer_overflow : 1;
-    uint16_t _inverse_logic : 1;
-
-    // static data
     static char _receive_buffer[_SS_MAX_RX_BUFF];
     static volatile uint8_t _receive_buffer_tail;
     static volatile uint8_t _receive_buffer_head;
-    static NewSoftwareSerial* active_object;
+    static NewSoftwareSerial* _instance; // single instance for ISR
 
-    // private methods
     void recv();
     uint8_t rx_pin_read();
     void tx_pin_write(uint8_t pin_state);
     void setTX(uint8_t transmitPin);
     void setRX(uint8_t receivePin);
 
-    // private static method for timing
     static inline void tunedDelay(uint16_t delay);
 
   public:
-    // public methods
-    NewSoftwareSerial(uint8_t receivePin, uint8_t transmitPin, bool inverse_logic = false);
+    NewSoftwareSerial(uint8_t receivePin, uint8_t transmitPin);
     ~NewSoftwareSerial();
+
     void begin(long speed);
-    bool listen();
     void end();
-    bool isListening() { return this == active_object; }
-    bool overflow()
+    size_t write(uint8_t byte);
+    int read();
+    int available();
+    bool isListening() { return _instance == this; }
+    // cppcheck-suppress functionStatic
+    void flush()
     {
-        bool ret = _buffer_overflow;
-        _buffer_overflow = false;
-        return ret;
+        uint8_t s = SREG;
+        cli();
+        _receive_buffer_head = _receive_buffer_tail = 0;
+        SREG = s;
     }
-    int peek();
 
-    virtual size_t write(uint8_t byte);
-    virtual int read();
-    virtual int available();
-    virtual void flush();
-
-    using Print::write;
-
-    // public only for easy access by interrupt handlers
     static inline void handle_interrupt();
 };
-
-// Arduino 0012 workaround
-#undef int
-#undef char
-#undef long
-#undef byte
-#undef float
-#undef abs
-#undef round
-
-#endif

--- a/test/test_obd_signals_more.cpp
+++ b/test/test_obd_signals_more.cpp
@@ -185,12 +185,11 @@ void test_signals_fuel_consumption_calculation()
     TEST_ASSERT_EQUAL_UINT16(100, signals.computed.elapsedKmSinceStart);
     TEST_ASSERT_EQUAL_UINT8(10, signals.computed.fuelBurnedSinceStart);
 
-    // Fuel consumption should be: 10L / 100km = 0.1L/km = 10L/100km
-    // fuelPer100km should be approximately 10.0
-    TEST_ASSERT_TRUE(signals.computed.fuelPer100km >= 9.0f && signals.computed.fuelPer100km <= 11.0f);
+    // fuelPer100km stored ×10: 10 L/100km → 100. Acceptable range [90, 110].
+    TEST_ASSERT_TRUE(signals.computed.fuelPer100km >= 90 && signals.computed.fuelPer100km <= 110);
 
-    // fuelPerHour should be approximately 5.0 (10L / 2h)
-    TEST_ASSERT_TRUE(signals.computed.fuelPerHour >= 4.0f && signals.computed.fuelPerHour <= 6.0f);
+    // fuelPerHour stored ×10: 5 L/h → 50. Acceptable range [40, 60].
+    TEST_ASSERT_TRUE(signals.computed.fuelPerHour >= 40 && signals.computed.fuelPerHour <= 60);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
#11 

- Replaced Wire library with direct AVR TWI registers: 1,693 bytes
- Replaced TaskScheduler with hand-rolled runner: 2,116 bytes
- Eliminated float arithmetic (removed soft-float library): 592 bytes
- Stripped NewSoftwareSerial to 5 KWP baud rates only: 686 bytes
- Compacted KWP formula table (13→3 bytes per entry): 196 bytes
- Collapsed MenuState navigation: 6 identical methods → 2 generic ones using indexed array: ~63 bytes
- Implemented Screen VM: replaced all 5 screen render functions with PROGMEM byte-stream scripts + shared interpreter. Added new screens now cost ~10 bytes of data instead of ~100+ bytes of code: ~2,674 bytes

----
Around 8KB saved